### PR TITLE
fix(ci): rename deprecation tracker branch to chore/ prefix

### DIFF
--- a/.github/workflows/azure-deprecation-tracker.yml
+++ b/.github/workflows/azure-deprecation-tracker.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(data): Update Azure deprecation tracking [skip ci]"
-          branch: "automation/azure-deprecation-tracker"
+          branch: "chore/azure-deprecation-tracker"
           delete-branch: true
           title: "chore(data): Update Azure deprecation tracking"
           body: |


### PR DESCRIPTION
The `automation/azure-deprecation-tracker` branch created by the weekly deprecation tracker workflow fails the Branch Naming Convention check because `automation/` is not an approved prefix.

**Fix:** Change the branch from `automation/azure-deprecation-tracker` to `chore/azure-deprecation-tracker`, which is a valid cross-cutting prefix exempt from scope checks.

**Fixes:** PR #238 CI failure

**After merging:**
1. Close PR #238 (stale `automation/` branch)
2. Delete the `automation/azure-deprecation-tracker` branch
3. Next weekly run will create a PR from the correct `chore/` branch