### PR TITLE
chore: update agents, skills, instructions, docs, and tooling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,8 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/terraform:1": {
-      "tflint": "0.61.0",
+      "tflint": "none",
+      "terragrunt": "none",
       "installTFsec": false
     },
     "ghcr.io/devcontainers/features/go:1": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -288,6 +288,36 @@ else
     step_warn "Go not found — Terraform MCP Server not installed"
 fi
 
+# ─── Step 9.4: TFLint (cosign-free install) ─────────────────────────────────
+# The terraform devcontainer feature installs the latest cosign (3.x) to verify
+# TFLint's signature, but cosign 3.x is incompatible with the Rekor log-query
+# API and aborts the whole feature install ("invalid signature when validating
+# IEEE_P1363 encoded signature"). We therefore set tflint=none in the feature
+# and install the pinned TFLint release directly here — no cosign required.
+
+TFLINT_VERSION="0.61.0"
+step_start "🧹" "Installing TFLint v${TFLINT_VERSION} (cosign-free)..."
+if command -v tflint &>/dev/null && tflint --version 2>/dev/null | grep -q "$TFLINT_VERSION"; then
+    step_done "TFLint v${TFLINT_VERSION} already installed"
+else
+    TFLINT_ARCH=$(dpkg --print-architecture)
+    if [ "$TFLINT_ARCH" = "amd64" ] || [ "$TFLINT_ARCH" = "arm64" ]; then
+        TFLINT_TMP=$(mktemp -d)
+        TFLINT_URL="https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TFLINT_ARCH}.zip"
+        if curl -fsSL "$TFLINT_URL" -o "$TFLINT_TMP/tflint.zip" \
+            && unzip -o -q "$TFLINT_TMP/tflint.zip" -d "$TFLINT_TMP" \
+            && sudo install -m 0755 "$TFLINT_TMP/tflint" /usr/local/bin/tflint; then
+            rm -rf "$TFLINT_TMP"
+            step_done "TFLint $(tflint --version 2>/dev/null | head -1)"
+        else
+            rm -rf "$TFLINT_TMP"
+            step_warn "TFLint install failed — check network access to github.com"
+        fi
+    else
+        step_warn "TFLint skipped: unsupported architecture $TFLINT_ARCH (supported: amd64, arm64)"
+    fi
+fi
+
 # ─── Step 9.5: Terraform CLI hardening ──────────────────────────────────────
 # The Terraform plugin-cache directory must exist before `terraform init` runs;
 # the CLI refuses to operate when TF_PLUGIN_CACHE_DIR points at a missing path.

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -304,7 +304,10 @@ else
     if [ "$TFLINT_ARCH" = "amd64" ] || [ "$TFLINT_ARCH" = "arm64" ]; then
         TFLINT_TMP=$(mktemp -d)
         TFLINT_URL="https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TFLINT_ARCH}.zip"
+        TFLINT_SHA_URL="https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/checksums.txt"
         if curl -fsSL "$TFLINT_URL" -o "$TFLINT_TMP/tflint.zip" \
+            && curl -fsSL "$TFLINT_SHA_URL" -o "$TFLINT_TMP/checksums.txt" \
+            && (cd "$TFLINT_TMP" && grep -E " tflint_linux_${TFLINT_ARCH}\.zip$" checksums.txt | sha256sum -c -) \
             && unzip -o -q "$TFLINT_TMP/tflint.zip" -d "$TFLINT_TMP" \
             && sudo install -m 0755 "$TFLINT_TMP/tflint" /usr/local/bin/tflint; then
             rm -rf "$TFLINT_TMP"

--- a/.github/agents/01-orchestrator.agent.md
+++ b/.github/agents/01-orchestrator.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 01-Orchestrator
 description: Master orchestrator for the multi-step Azure platform engineering workflow. Coordinates Requirements, Architect, Design, IaC Plan, IaC Code, Deploy agents with mandatory human approval gates. Routes Bicep or Terraform tracks via decisions.iac_tool.
-model: ["GPT-5.4 mini"]
+model: ["MAI-Code-1-Flash"]
 argument-hint: Describe the Azure platform engineering project you want to build end-to-end
 user-invocable: true
 agents:
@@ -145,8 +145,7 @@ chat can resume losslessly.
     before continuing (circuit breaker — see Core Principles).
   - At Gates 2 and 3, recommend a session break unless context is below 40%.
 - Reasoning effort: rely on the Copilot runtime default. Do not request `high`
-  reflexively — GPT-5.5 reasons more efficiently than predecessors; escalate
-  only when a gate carries unresolved tradeoffs.
+  reflexively; escalate only when a gate carries unresolved tradeoffs.
 - Subagent budget: not applicable — the orchestrator does not invoke step
   agents or the challenger via `#runSubagent`. The cost-estimate, validate,
   what-if/plan, and challenger subagents are owned by the step agents that
@@ -199,7 +198,7 @@ subagent cannot exceed the cost tier of the parent. If the parent requests a
 higher-tier model, the subagent silently falls back to the parent's tier.
 [Reference](https://code.visualstudio.com/docs/copilot/agents/subagents).
 
-This orchestrator runs at **standard** tier (GPT-5.4 mini). The step agents and
+This orchestrator runs at **standard** tier (MAI-Code-1-Flash). The step agents and
 the challenger run at **medium** (GPT-5.5 / Sonnet 4.6) or **high** (Opus 4.7)
 tiers. Calling them via `#runSubagent` would silently downgrade them to
 standard tier and produce wrong-tier output for architecture, planning, and
@@ -539,7 +538,7 @@ Orchestrator with the project name — no special resume prompt needed.
 | `high`     | Claude Opus 4.8   | Architecture, Planning, Context Optimizer                                                         |
 | `medium`   | Claude Sonnet 4.6 | **Requirements**, Design, Bicep/Terraform CodeGen, Bicep/Terraform validate + preview subagents   |
 | `medium`   | GPT-5.5           | Governance, Deploy, As-Built, Diagnose, Challenger, E2E orchestrator                              |
-| `standard` | GPT-5.4 mini      | **Orchestrator** (handoff-only routing)                                                           |
+| `standard` | MAI-Code-1-Flash  | **Orchestrator** (handoff-only routing)                                                           |
 | `codex`    | GPT-5.3-Codex     | Cost estimate subagent                                                                            |
 
 > The canonical assignments live in

--- a/.github/agents/01-orchestrator.agent.md
+++ b/.github/agents/01-orchestrator.agent.md
@@ -199,7 +199,7 @@ higher-tier model, the subagent silently falls back to the parent's tier.
 [Reference](https://code.visualstudio.com/docs/copilot/agents/subagents).
 
 This orchestrator runs at **standard** tier (MAI-Code-1-Flash). The step agents and
-the challenger run at **medium** (GPT-5.5 / Sonnet 4.6) or **high** (Opus 4.7)
+the challenger run at **medium** (GPT-5.5 / Sonnet 4.6) or **high** (Claude Opus 4.8)
 tiers. Calling them via `#runSubagent` would silently downgrade them to
 standard tier and produce wrong-tier output for architecture, planning, and
 documentation work.

--- a/.github/instructions/agent-authoring.instructions.md
+++ b/.github/instructions/agent-authoring.instructions.md
@@ -151,10 +151,15 @@ Agents that specify `Claude Opus 4.7` as priority model do so deliberately:
   Success / Constraints / Output / Stop sections, retrieval budgets, decision rules
   over absolutes, and stopping conditions. GPT-5.5 reasons more efficiently than
   predecessors — re-evaluate `low`/`medium` reasoning effort before escalating
-- **GPT-5.4 mini agents** (orchestrator) use the same GPT-5.x prompting style
-  as the GPT-5.5 cohort (per vendor-prompting `family-support.md` — GPT-5.4
-  shares the OpenAI cohort rules). Lower-cost tier suits handoff-only routing
-  with no creative generation.
+- **GPT-5.4 mini prompts** (utility/CLI prompts such as apex-git-commit,
+  apex-debug-log-export) use the same GPT-5.x prompting style as the GPT-5.5
+  cohort (per vendor-prompting `family-support.md` — GPT-5.4 shares the OpenAI
+  cohort rules). Lower-cost tier suits deterministic CLI workflows.
+- **MAI-Code-1-Flash agents** (orchestrator) run Microsoft's fast coding model
+  for handoff-only routing with no creative generation. The `mai-code` family
+  is `reviewer-only` in vendor-prompting — no MAI-specific automated rules yet;
+  the orchestrator body keeps its outcome-first skeleton as a sound routing
+  structure.
 - **GPT-5.3-Codex subagents** handle narrow, high-throughput tasks (cost estimation)
 
 #### GPT-5.5 prompting style (summary)
@@ -178,7 +183,7 @@ Current model assignments:
 
 | Agent / Group                       | Model             | Rationale                                |
 | ----------------------------------- | ----------------- | ---------------------------------------- |
-| Orchestrator                        | GPT-5.4 mini      | Standard-tier handoff routing            |
+| Orchestrator                        | MAI-Code-1-Flash  | Standard-tier handoff routing            |
 | Orchestrator (Fast Path)            | GPT-5.5           | Streamlined orchestration                |
 | Requirements                        | Claude Sonnet 4.6 | One-shot discovery (Anthropic style)     |
 | Architect                           | Claude Opus 4.8   | WAF analysis + cost (high effort)        |

--- a/.github/model-catalog.json
+++ b/.github/model-catalog.json
@@ -1,14 +1,17 @@
 {
   "$schema": "../tools/schemas/model-catalog.schema.json",
   "description": "Authorized Copilot Chat model labels for APEX agents. Two-part design: `models` is hand-maintained metadata that authorizes which labels may appear in agent frontmatter; `assignments` is auto-generated from frontmatter (the canonical source) so the catalog can never drift from the agents themselves. The agent registry mirrors frontmatter via validate-model-consistency.mjs; the catalog enforces the label allow-list and assignment integrity via validate-model-catalog.mjs.",
-  "last_updated": "2026-05-28",
+  "last_updated": "2026-06-08",
   "models": {
     "Claude Opus 4.8": {
       "vendor": "Anthropic",
       "tier": "frontier",
       "released": "2026-05",
       "deprecated": false,
-      "use_for": ["architecture", "iac-planning"],
+      "use_for": [
+        "architecture",
+        "iac-planning"
+      ],
       "notes": "Anthropic's most capable model. Drop-in upgrade from Opus 4.7 (no API-breaking changes): same tools/features, adaptive thinking only, sampling params unsupported. Improves long-horizon agentic coding, reasoning-effort calibration, tool triggering, and compaction recovery; effort defaults to `high` on all surfaces. Authorized 2026-05 for Architecture (03) and IaC Planning (05). Reasoning-effort policy (high vs default) is a per-agent / per-call concern, NOT a separate model label — see `.github/instructions/agent-authoring.instructions.md`."
     },
     "Claude Opus 4.7": {
@@ -16,7 +19,12 @@
       "tier": "frontier",
       "released": "2026-05",
       "deprecated": false,
-      "use_for": ["orchestration", "architecture", "iac-planning", "context-optimization"],
+      "use_for": [
+        "orchestration",
+        "architecture",
+        "iac-planning",
+        "context-optimization"
+      ],
       "notes": "Active Opus 4.7 SKU. Reasoning-effort policy (high vs default) is a per-agent / per-call concern, NOT a separate model label. See `.github/instructions/agent-authoring.instructions.md` (\"Reasoning-effort policy\" section) for guidance on which agents run at high effort."
     },
     "Claude Opus 4.6": {
@@ -24,7 +32,13 @@
       "tier": "frontier",
       "released": "2026-01",
       "deprecated": true,
-      "use_for": ["orchestration", "architecture", "iac-planning", "diagnosis", "context-optimization"],
+      "use_for": [
+        "orchestration",
+        "architecture",
+        "iac-planning",
+        "diagnosis",
+        "context-optimization"
+      ],
       "notes": "Deprecated 2026-05 in favor of Claude Opus 4.7. Retained for audit history; not authorized for new agents."
     },
     "Claude Sonnet 4.6": {
@@ -32,7 +46,14 @@
       "tier": "balanced",
       "released": "2026-01",
       "deprecated": false,
-      "use_for": ["design-diagrams", "adr-authoring", "iac-codegen", "iac-validation", "deployment-preview", "as-built-documentation"],
+      "use_for": [
+        "design-diagrams",
+        "adr-authoring",
+        "iac-codegen",
+        "iac-validation",
+        "deployment-preview",
+        "as-built-documentation"
+      ],
       "notes": "Active for Step 3 Design, Step 5 IaC code generation (Bicep + Terraform), Step 7 As-Built documentation, and the IaC validation/preview subagents (bicep-validate, bicep-whatif, terraform-validate, terraform-plan). The Anthropic prompting style (XML-tagged blocks, role-first, quote-grounded review, checklist-driven structured output) suits ADR + diagram authoring, the structured PASS/FAIL findings produced by the validation subagents, and the checklist-driven artifact generation of as-built docs. CodeGen joined this cohort 2026-05 (was GPT-5.5) for stronger verbatim invariant retention. As-Built joined 2026-05 for the same XML-structured artifact authoring alignment. Other GPT-5.5 cohort members (Governance, Deploy, Challenger, E2E, Diagnose) remain on GPT-5.5."
     },
     "GPT-5.4": {
@@ -40,7 +61,12 @@
       "tier": "standard",
       "released": "2026-02",
       "deprecated": false,
-      "use_for": ["deployment", "as-built", "validation-subagents", "whatif-interpretation"],
+      "use_for": [
+        "deployment",
+        "as-built",
+        "validation-subagents",
+        "whatif-interpretation"
+      ],
       "notes": "Active OpenAI standard-tier SKU. Re-authorized 2026-05 after the deprecation flag was lifted (no `GPT-5.5 mini` exists, so the `GPT-5.4` cohort remains the lower-cost OpenAI tier alongside `GPT-5.5`). Pair with `GPT-5.4 mini` for utility/CLI prompts."
     },
     "GPT-5.4 mini": {
@@ -48,7 +74,11 @@
       "tier": "mini",
       "released": "2026-05",
       "deprecated": false,
-      "use_for": ["utility-prompts", "cli-operations", "lightweight-tasks"],
+      "use_for": [
+        "utility-prompts",
+        "cli-operations",
+        "lightweight-tasks"
+      ],
       "notes": "Lightweight, cost-optimized model for utility prompts and CLI-only workflows. Suitable for straightforward git operations, file staging, and deterministic CLI parsing. Not for complex orchestration or reasoning-heavy tasks."
     },
     "GPT-5.5": {
@@ -73,8 +103,22 @@
       "tier": "codex",
       "released": "2025-12",
       "deprecated": false,
-      "use_for": ["cost-estimation", "parametric-calculations"],
+      "use_for": [
+        "cost-estimation",
+        "parametric-calculations"
+      ],
       "notes": "Code/maths-focused. Used by cost-estimate-subagent for numerical reasoning."
+    },
+    "MAI-Code-1-Flash": {
+      "vendor": "Microsoft",
+      "tier": "standard",
+      "released": "2026-06",
+      "deprecated": false,
+      "use_for": [
+        "orchestration",
+        "handoff-routing"
+      ],
+      "notes": "Microsoft's fast, cost-optimized coding model. Authorized 2026-06 for the Orchestrator (01), which performs handoff-only routing with no creative generation — a lightweight standard-tier model is sufficient. No MAI-specific automated prompting rules exist yet; the `mai-code` family is `reviewer-only` in vendor-prompting (see `.github/skills/vendor-prompting/references/family-support.md`). The orchestrator body retains its outcome-first skeleton (Role/Goal/Success/Constraints/Output/Stop), which remains a sound structure for a routing agent."
     }
   },
   "governance": {
@@ -91,7 +135,7 @@
     "generated_by": "tools/scripts/generate-model-catalog.mjs",
     "description": "Auto-generated inventory of agent → model assignments derived from frontmatter (canonical source). Do not edit by hand; run `node tools/scripts/generate-model-catalog.mjs` or let the lefthook pre-commit hook refresh it when frontmatter changes.",
     "agents": {
-      "01-orchestrator.agent.md": "GPT-5.4 mini",
+      "01-orchestrator.agent.md": "MAI-Code-1-Flash",
       "02-requirements.agent.md": "Claude Sonnet 4.6",
       "03-architect.agent.md": "Claude Opus 4.8",
       "04-design.agent.md": "Claude Sonnet 4.6",

--- a/.github/skills/docs-writer/references/repo-architecture.md
+++ b/.github/skills/docs-writer/references/repo-architecture.md
@@ -43,7 +43,7 @@ See `tools/registry/count-manifest.json` for canonical counts.
 
 | Agent             | File                             | Model                     | Step | Artifacts                       |
 | ----------------- | -------------------------------- | ------------------------- | ---- | ------------------------------- |
-| Orchestrator      | `01-orchestrator.agent.md`       | GPT-5.4 mini              | All  | Orchestration                   |
+| Orchestrator      | `01-orchestrator.agent.md`       | MAI-Code-1-Flash          | All  | Orchestration                   |
 | Requirements      | `02-requirements.agent.md`       | Claude Sonnet 4.6         | 1    | `01-requirements.md`            |
 | Architect         | `03-architect.agent.md`          | Opus 4.7 (High reasoning) | 2    | `02-architecture-assessment.md` |
 | Design            | `04-design.agent.md`             | Sonnet 4.6                | 3    | `03-des-*.{drawio,py,png,md}`   |

--- a/.github/skills/vendor-prompting/references/family-support.md
+++ b/.github/skills/vendor-prompting/references/family-support.md
@@ -30,6 +30,7 @@ Family status determines per-rule severity overrides.
 | `gpt-5.4`       | enforced      | GPT-5.5 rules apply (shared OpenAI cohort)         | `GPT-5.4`           |
 | `gpt-codex`     | reviewer-only | Decision-log only; no automated enforcement        | `GPT-5.3-Codex`     |
 | `gpt-4o`        | reviewer-only | Legacy; no new enforcement                         | `GPT-4o`            |
+| `mai-code`      | reviewer-only | Microsoft model; no MAI-specific prompting rules   | `MAI-Code-1-Flash`  |
 | `unknown`       | enforced      | Raises ERROR to force explicit `model:` value      | (anything else)     |
 
 ## How severity is computed

--- a/.github/skills/vendor-prompting/rules.json
+++ b/.github/skills/vendor-prompting/rules.json
@@ -74,6 +74,12 @@
       "rule_subset_note": "Legacy model; no new enforcement."
     },
     {
+      "family": "mai-code",
+      "status": "reviewer-only",
+      "label_examples": ["MAI-Code-1-Flash"],
+      "rule_subset_note": "Microsoft coding model; no MAI-specific automated prompting rules yet. Used for handoff-only orchestration routing."
+    },
+    {
       "family": "unknown",
       "status": "enforced",
       "label_examples": [],

--- a/.markdown-link-check-site.json
+++ b/.markdown-link-check-site.json
@@ -40,6 +40,9 @@
       "pattern": "^https://trust\\.github\\.com"
     },
     {
+      "pattern": "^https://github\\.com"
+    },
+    {
       "pattern": "^https://azure\\.microsoft\\.com"
     },
     {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -224,7 +224,7 @@ pre-commit:
 
     secrets-baseline:
       run: |
-        if command -v gitleaks &>/dev/null; then
+        if command -v gitleaks >/dev/null 2>&1; then
           gitleaks protect --staged --redact --no-banner
         else
           echo "⚠️  gitleaks not installed — skipping secret scan (CI will enforce)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint-formatter-compact": "^9.0.1",
         "eslint-plugin-n": "^18.0.1",
         "fast-xml-parser": "^5.8.0",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.1.1",
         "jsdom": "^29.1.1",
         "lefthook": "^2.1.8",
         "markdown-link-check": "^3.14.2",

--- a/site/public/architecture-explorer-graph.json
+++ b/site/public/architecture-explorer-graph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../tools/schemas/explorer-graph.schema.json",
-  "generatedAt": "2026-05-28T20:24:28.166Z",
+  "generatedAt": "2026-06-08T06:45:03.162Z",
   "categories": [
     {
       "id": "agent",
@@ -80,7 +80,7 @@
         "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/agents/01-orchestrator.agent.md"
       },
       "meta": {
-        "model": "GPT-5.4 mini",
+        "model": "MAI-Code-1-Flash",
         "invocable": true,
         "subagents": [
           "02-Requirements",

--- a/site/src/content/docs/concepts/how-it-works/agents.md
+++ b/site/src/content/docs/concepts/how-it-works/agents.md
@@ -267,9 +267,10 @@ Model selection depends on the task. Use `tools/registry/agent-registry.json` as
 source of truth, but the current repo pattern is:
 
 - **Planning agents** (accuracy-first) — typically `Claude Opus 4.7` at high reasoning effort
-- **Orchestrator** — `GPT-5.4 mini` with the OpenAI outcome-first prompting style
-  (Role / Personality / Goal / Success / Constraints / Output / Stop). Standard
-  tier suits handoff-only routing without creative generation.
+- **Orchestrator** — `MAI-Code-1-Flash`, Microsoft's fast coding model. Standard
+  tier suits handoff-only routing without creative generation; the agent body
+  keeps its outcome-first skeleton (Role / Goal / Success / Constraints / Output /
+  Stop) as a sound routing structure.
 - **Design + Code generation** — `Claude Sonnet 4.6` for Anthropic XML-tagged
   output contracts and stronger verbatim invariant retention (security baseline,
   AVM contract, HARD GATE language)

--- a/site/src/content/docs/concepts/workflow.md
+++ b/site/src/content/docs/concepts/workflow.md
@@ -136,7 +136,7 @@ preview subagents before any Azure changes are applied.
 
 | Agent            | Codename        | Role                                        | Model           |
 | ---------------- | --------------- | ------------------------------------------- | --------------- |
-| **Orchestrator** | 🧠 Orchestrator | Master orchestrator for multi-step workflow | GPT-5.4 mini    |
+| **Orchestrator** | 🧠 Orchestrator | Master orchestrator for multi-step workflow | MAI-Code-1-Flash |
 
 ### Core Agents (by Workflow Step)
 

--- a/tools/registry/agent-registry.json
+++ b/tools/registry/agent-registry.json
@@ -4,7 +4,7 @@
   "agents": {
     "orchestrator": {
       "agent": ".github/agents/01-orchestrator.agent.md",
-      "model": "GPT-5.4 mini",
+      "model": "MAI-Code-1-Flash",
       "invokable": true,
       "step": null
     },

--- a/tools/schemas/vendor-prompting-rules.schema.json
+++ b/tools/schemas/vendor-prompting-rules.schema.json
@@ -58,6 +58,7 @@
               "gpt-5.4",
               "gpt-codex",
               "gpt-4o",
+              "mai-code",
               "unknown"
             ]
           },
@@ -113,6 +114,7 @@
                 "gpt-5.4",
                 "gpt-codex",
                 "gpt-4o",
+                "mai-code",
                 "any"
               ]
             }

--- a/tools/scripts/validate-agents.mjs
+++ b/tools/scripts/validate-agents.mjs
@@ -369,6 +369,7 @@ function classifyModel(modelStr) {
   if (lower.includes("gpt-5.4")) return "gpt-5.4";
   if (lower.includes("gpt-5.3") || lower.includes("codex")) return "gpt-codex";
   if (lower.includes("gpt-4o")) return "gpt-4o";
+  if (lower.includes("mai-code") || lower.includes("mai code")) return "mai-code";
   return "unknown";
 }
 

--- a/tools/scripts/validate-agents.mjs
+++ b/tools/scripts/validate-agents.mjs
@@ -673,6 +673,7 @@ const FAMILY_STATUS = {
   "gpt-5.4": "deprecated",
   "gpt-codex": "reviewer-only",
   "gpt-4o": "reviewer-only",
+  "mai-code": "reviewer-only",
   unknown: "enforced",
 };
 

--- a/tools/tests/validate-agents/classify-model.test.mjs
+++ b/tools/tests/validate-agents/classify-model.test.mjs
@@ -47,6 +47,11 @@ test("classifyModel: GPT-4o → gpt-4o", () => {
   assert.equal(classifyModel("GPT-4o"), "gpt-4o");
 });
 
+test("classifyModel: MAI-Code-1-Flash → mai-code", () => {
+  assert.equal(classifyModel("MAI-Code-1-Flash"), "mai-code");
+  assert.equal(classifyModel(["MAI-Code-1-Flash"]), "mai-code");
+});
+
 test("classifyModel: unknown / missing → unknown", () => {
   assert.equal(classifyModel(undefined), "unknown");
   assert.equal(classifyModel(null), "unknown");


### PR DESCRIPTION
## Summary

- Update 01-Orchestrator agent definition
- Update agent-authoring instructions
- Update model-catalog.json
- Update vendor-prompting skill (rules.json, family-support.md)
- Update docs-writer skill repo-architecture reference
- Update devcontainer config and post-create script
- Update architecture-explorer graph and site docs (agents, workflow)
- Update agent-registry.json and validate-agents script/tests
- Update package-lock.json deps
- Fix lefthook `secrets-baseline` hook to use POSIX-compatible redirection (`>/dev/null 2>&1` instead of `&>/dev/null`)