### PR TITLE
chore(rename): update cross-repo links to apex-accelerator + microhack.apexops.pro

### DIFF
--- a/.github/terminology-blocklist.json
+++ b/.github/terminology-blocklist.json
@@ -120,7 +120,7 @@
     "infraops-health-checks",
     "infraops-remediation-playbooks",
     "my-infraops-project",
-    "microhack-agentic-infraops",
+    "apex-microhack",
     "agentic-infraops.PPTX",
     "Vocab = InfraOps",
     "InfraOps / SRE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ```bash
 # Clone the Accelerator template and open in dev container
-# https://github.com/jonathan-vella/azure-agentic-infraops-accelerator
+# https://github.com/jonathan-vella/apex-accelerator
 git clone https://github.com/YOUR-USERNAME/my-infraops-project.git && cd my-infraops-project
 code . # then: F1 → Dev Containers: Reopen in Container
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The full documentation for this repository lives here:
 
 Key entry points:
 
-- [Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
-- [MicroHack](https://jonathan-vella.github.io/microhack-agentic-infraops/)
+- [Accelerator template](https://github.com/jonathan-vella/apex-accelerator)
+- [MicroHack](https://microhack.apexops.pro/)
 - [Contributing guide](CONTRIBUTING.md)
 
 ## Workflow
@@ -112,7 +112,7 @@ sequenceDiagram
 For new projects, use the Accelerator template rather than cloning this repository
 directly.
 
-1. Create a repository from the [Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator).
+1. Create a repository from the [Accelerator template](https://github.com/jonathan-vella/apex-accelerator).
 2. Open that repository in VS Code and reopen it in the dev container.
 3. Start with the published docs:
    [https://apexops.pro/](https://apexops.pro/)

--- a/site/public/architecture-explorer-graph.json
+++ b/site/public/architecture-explorer-graph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../tools/schemas/explorer-graph.schema.json",
-  "generatedAt": "2026-06-08T11:11:02.177Z",
+  "generatedAt": "2026-06-08T13:09:34.547Z",
   "categories": [
     {
       "id": "agent",
@@ -111,7 +111,12 @@
           "09-Diagnose",
           "10-Challenger"
         ],
-        "skills": ["golden-principles", "azure-defaults", "azure-artifacts", "workflow-engine"]
+        "skills": [
+          "golden-principles",
+          "azure-defaults",
+          "azure-artifacts",
+          "workflow-engine"
+        ]
       }
     },
     {
@@ -126,9 +131,19 @@
       "meta": {
         "model": "Claude Sonnet 4.6",
         "invocable": true,
-        "subagents": ["challenger-review-subagent"],
-        "handoffTargets": ["02-Requirements", "10-Challenger", "03-Architect", "01-Orchestrator"],
-        "skills": ["azure-defaults", "azure-artifacts"]
+        "subagents": [
+          "challenger-review-subagent"
+        ],
+        "handoffTargets": [
+          "02-Requirements",
+          "10-Challenger",
+          "03-Architect",
+          "01-Orchestrator"
+        ],
+        "skills": [
+          "azure-defaults",
+          "azure-artifacts"
+        ]
       }
     },
     {
@@ -143,9 +158,22 @@
       "meta": {
         "model": "Claude Opus 4.8",
         "invocable": true,
-        "subagents": ["cost-estimate-subagent", "challenger-review-subagent"],
-        "handoffTargets": ["03-Architect", "04-Design", "04g-Governance", "02-Requirements", "01-Orchestrator"],
-        "skills": ["azure-defaults", "azure-artifacts", "context-management"]
+        "subagents": [
+          "cost-estimate-subagent",
+          "challenger-review-subagent"
+        ],
+        "handoffTargets": [
+          "03-Architect",
+          "04-Design",
+          "04g-Governance",
+          "02-Requirements",
+          "01-Orchestrator"
+        ],
+        "skills": [
+          "azure-defaults",
+          "azure-artifacts",
+          "context-management"
+        ]
       }
     },
     {
@@ -160,9 +188,22 @@
       "meta": {
         "model": "Claude Sonnet 4.6",
         "invocable": true,
-        "subagents": ["challenger-review-subagent"],
-        "handoffTargets": ["04-Design", "03-Architect", "04g-Governance", "01-Orchestrator"],
-        "skills": ["azure-defaults", "azure-artifacts", "azure-adr", "drawio", "python-diagrams"]
+        "subagents": [
+          "challenger-review-subagent"
+        ],
+        "handoffTargets": [
+          "04-Design",
+          "03-Architect",
+          "04g-Governance",
+          "01-Orchestrator"
+        ],
+        "skills": [
+          "azure-defaults",
+          "azure-artifacts",
+          "azure-adr",
+          "drawio",
+          "python-diagrams"
+        ]
       }
     },
     {
@@ -177,9 +218,20 @@
       "meta": {
         "model": "GPT-5.3-Codex",
         "invocable": true,
-        "subagents": ["challenger-review-subagent"],
-        "handoffTargets": ["04g-Governance", "05-IaC Planner", "01-Orchestrator"],
-        "skills": ["azure-defaults", "azure-governance-discovery", "azure-artifacts", "iac-common"]
+        "subagents": [
+          "challenger-review-subagent"
+        ],
+        "handoffTargets": [
+          "04g-Governance",
+          "05-IaC Planner",
+          "01-Orchestrator"
+        ],
+        "skills": [
+          "azure-defaults",
+          "azure-governance-discovery",
+          "azure-artifacts",
+          "iac-common"
+        ]
       }
     },
     {
@@ -194,7 +246,9 @@
       "meta": {
         "model": "Claude Opus 4.8",
         "invocable": true,
-        "subagents": ["challenger-review-subagent"],
+        "subagents": [
+          "challenger-review-subagent"
+        ],
         "handoffTargets": [
           "04g-Governance",
           "05-IaC Planner",
@@ -225,9 +279,22 @@
       "meta": {
         "model": "Claude Sonnet 4.6",
         "invocable": true,
-        "subagents": ["bicep-validate-subagent", "challenger-review-subagent"],
-        "handoffTargets": ["06b-Bicep CodeGen", "07b-Bicep Deploy", "05-IaC Planner", "01-Orchestrator"],
-        "skills": ["azure-defaults", "azure-artifacts", "azure-bicep-patterns", "context-management"]
+        "subagents": [
+          "bicep-validate-subagent",
+          "challenger-review-subagent"
+        ],
+        "handoffTargets": [
+          "06b-Bicep CodeGen",
+          "07b-Bicep Deploy",
+          "05-IaC Planner",
+          "01-Orchestrator"
+        ],
+        "skills": [
+          "azure-defaults",
+          "azure-artifacts",
+          "azure-bicep-patterns",
+          "context-management"
+        ]
       }
     },
     {
@@ -242,9 +309,22 @@
       "meta": {
         "model": "Claude Sonnet 4.6",
         "invocable": true,
-        "subagents": ["terraform-validate-subagent", "challenger-review-subagent"],
-        "handoffTargets": ["06t-Terraform CodeGen", "07t-Terraform Deploy", "05-IaC Planner", "01-Orchestrator"],
-        "skills": ["azure-defaults", "azure-artifacts", "terraform-patterns", "context-management"]
+        "subagents": [
+          "terraform-validate-subagent",
+          "challenger-review-subagent"
+        ],
+        "handoffTargets": [
+          "06t-Terraform CodeGen",
+          "07t-Terraform Deploy",
+          "05-IaC Planner",
+          "01-Orchestrator"
+        ],
+        "skills": [
+          "azure-defaults",
+          "azure-artifacts",
+          "terraform-patterns",
+          "context-management"
+        ]
       }
     },
     {
@@ -265,8 +345,18 @@
           "policy-precheck-subagent",
           "challenger-review-subagent"
         ],
-        "handoffTargets": ["07b-Bicep Deploy", "08-As-Built", "06b-Bicep CodeGen", "03-Architect", "01-Orchestrator"],
-        "skills": ["azure-defaults", "azure-artifacts", "iac-common"]
+        "handoffTargets": [
+          "07b-Bicep Deploy",
+          "08-As-Built",
+          "06b-Bicep CodeGen",
+          "03-Architect",
+          "01-Orchestrator"
+        ],
+        "skills": [
+          "azure-defaults",
+          "azure-artifacts",
+          "iac-common"
+        ]
       }
     },
     {
@@ -294,7 +384,11 @@
           "03-Architect",
           "01-Orchestrator"
         ],
-        "skills": ["azure-defaults", "azure-artifacts", "iac-common"]
+        "skills": [
+          "azure-defaults",
+          "azure-artifacts",
+          "iac-common"
+        ]
       }
     },
     {
@@ -309,9 +403,20 @@
       "meta": {
         "model": "Claude Sonnet 4.6",
         "invocable": true,
-        "subagents": ["cost-estimate-subagent"],
-        "handoffTargets": ["08-As-Built", "01-Orchestrator"],
-        "skills": ["azure-defaults", "azure-artifacts", "drawio", "python-diagrams", "context-management"]
+        "subagents": [
+          "cost-estimate-subagent"
+        ],
+        "handoffTargets": [
+          "08-As-Built",
+          "01-Orchestrator"
+        ],
+        "skills": [
+          "azure-defaults",
+          "azure-artifacts",
+          "drawio",
+          "python-diagrams",
+          "context-management"
+        ]
       }
     },
     {
@@ -327,8 +432,16 @@
         "model": "GPT-5.5",
         "invocable": true,
         "subagents": [],
-        "handoffTargets": ["09-Diagnose", "08-As-Built", "03-Architect", "01-Orchestrator"],
-        "skills": ["azure-defaults", "azure-diagnostics"]
+        "handoffTargets": [
+          "09-Diagnose",
+          "08-As-Built",
+          "03-Architect",
+          "01-Orchestrator"
+        ],
+        "skills": [
+          "azure-defaults",
+          "azure-diagnostics"
+        ]
       }
     },
     {
@@ -343,8 +456,12 @@
       "meta": {
         "model": "GPT-5.3-Codex",
         "invocable": true,
-        "subagents": ["challenger-review-subagent"],
-        "handoffTargets": ["01-Orchestrator"],
+        "subagents": [
+          "challenger-review-subagent"
+        ],
+        "handoffTargets": [
+          "01-Orchestrator"
+        ],
         "skills": []
       }
     },
@@ -361,8 +478,13 @@
         "model": "Claude Sonnet 4.6",
         "invocable": true,
         "subagents": [],
-        "handoffTargets": ["01-Orchestrator"],
-        "skills": ["golden-principles", "context-management"]
+        "handoffTargets": [
+          "01-Orchestrator"
+        ],
+        "skills": [
+          "golden-principles",
+          "context-management"
+        ]
       }
     },
     {
@@ -395,7 +517,10 @@
           "terraform-plan-subagent"
         ],
         "handoffTargets": [],
-        "skills": ["azure-defaults", "azure-artifacts"]
+        "skills": [
+          "azure-defaults",
+          "azure-artifacts"
+        ]
       }
     },
     {
@@ -409,7 +534,10 @@
       },
       "meta": {
         "model": "Claude Sonnet 4.6",
-        "skills": ["azure-defaults", "iac-common"]
+        "skills": [
+          "azure-defaults",
+          "iac-common"
+        ]
       }
     },
     {
@@ -437,7 +565,10 @@
       },
       "meta": {
         "model": "GPT-5.5",
-        "skills": ["golden-principles", "azure-defaults"]
+        "skills": [
+          "golden-principles",
+          "azure-defaults"
+        ]
       }
     },
     {
@@ -451,7 +582,9 @@
       },
       "meta": {
         "model": "GPT-5.3-Codex",
-        "skills": ["azure-defaults"]
+        "skills": [
+          "azure-defaults"
+        ]
       }
     },
     {
@@ -493,7 +626,10 @@
       },
       "meta": {
         "model": "Claude Sonnet 4.6",
-        "skills": ["azure-defaults", "iac-common"]
+        "skills": [
+          "azure-defaults",
+          "iac-common"
+        ]
       }
     },
     {

--- a/site/src/components/AgentChat.astro
+++ b/site/src/components/AgentChat.astro
@@ -1,6 +1,6 @@
 ---
 // AgentChat — Visual mockup of AI agents orchestrating Azure infrastructure
-// Adapted from microhack-agentic-infraops for the main project docs
+// Adapted from apex-microhack for the main project docs
 ---
 
 <div class="agent-chat">

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -21,7 +21,7 @@ const buildDate = import.meta.env.PUBLIC_BUILD_DATE || "";
     <p class="footer-meta">
       <a href="https://github.com/jonathan-vella/apex/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>
       <span class="footer-sep">·</span>
-      <a href="https://github.com/jonathan-vella/azure-agentic-infraops-accelerator" target="_blank" rel="noopener noreferrer">Accelerator Template</a>
+      <a href="https://github.com/jonathan-vella/apex-accelerator" target="_blank" rel="noopener noreferrer">Accelerator Template</a>
       <span class="footer-sep">·</span>
       <a href="/sitemap-index.xml">Sitemap</a>
       <span class="footer-sep">·</span>

--- a/site/src/content/docs/getting-started/dev-containers.md
+++ b/site/src/content/docs/getting-started/dev-containers.md
@@ -101,7 +101,7 @@ code .
 
 :::note[Use the template repository]
 Do not clone this upstream project directly. Create your own repo from the
-[Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
+[Accelerator template](https://github.com/jonathan-vella/apex-accelerator)
 first. See the [Quickstart](../quickstart/) for the full setup flow.
 :::
 

--- a/site/src/content/docs/getting-started/quickstart.md
+++ b/site/src/content/docs/getting-started/quickstart.md
@@ -12,7 +12,7 @@ Get running in 10 minutes.
 :::note[Template repository]
 You do **not** clone this repository directly. Instead, you create your own
 repository from the
-[Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator),
+[Accelerator template](https://github.com/jonathan-vella/apex-accelerator),
 which gives you a clean starting point with all agents, skills, and dev container
 configuration ready to go.
 :::
@@ -60,7 +60,7 @@ but the minimum working configuration is included below so you do not miss it.
 ## Step 1: Create Your Repository from the Template
 
 1. Go to the
-   [Accelerator template repository](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
+   [Accelerator template repository](https://github.com/jonathan-vella/apex-accelerator)
 2. Select the green **Use this template** button → **Create a new repository**
 3. Choose an owner and repository name (e.g. `my-infraops-project`)
 4. Select **Public** or **Private** visibility
@@ -350,7 +350,7 @@ Pick the path that matches your goal — then drop into the resource table below
 | Goal                            | Resource                                                                                                  |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | Understand the full workflow    | [workflow.md](../../concepts/workflow/)                                                                   |
-| Try a guided hands-on challenge | [MicroHack](https://jonathan-vella.github.io/microhack-agentic-infraops/)                                 |
+| Try a guided hands-on challenge | [MicroHack](https://microhack.apexops.pro/)                                 |
 | Try a complete workflow         | [Prompt Guide](../../guides/prompt-guide/)                                                                |
 | Review mandatory guardrails     | [Security Baseline](../../reference/security-baseline/) and [Cost Governance](../../reference/cost-governance/) |
 | Generate architecture diagrams  | Use `drawio` skill (or `python-diagrams` for charts)                                                      |

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -24,7 +24,7 @@ import AgentChat from "../../components/AgentChat.astro";
       <a class="sl-link-button primary not-content" href="getting-started/quickstart/">
         Get Started
       </a>
-      <a class="sl-link-button minimal not-content" href="https://github.com/jonathan-vella/azure-agentic-infraops-accelerator">
+      <a class="sl-link-button minimal not-content" href="https://github.com/jonathan-vella/apex-accelerator">
         Use the Template
       </a>
     </div>

--- a/site/src/content/docs/project/contributing.md
+++ b/site/src/content/docs/project/contributing.md
@@ -171,7 +171,7 @@ feedback. No harassment or discrimination.
 By contributing, you agree that your contributions will be licensed under
 the [MIT License][license].
 
-[accelerator]: https://github.com/jonathan-vella/azure-agentic-infraops-accelerator
+[accelerator]: https://github.com/jonathan-vella/apex-accelerator
 [conventional-commits]: https://www.conventionalcommits.org/
 [discussions]: https://github.com/jonathan-vella/apex/discussions
 [issues]: https://github.com/jonathan-vella/apex/issues

--- a/site/src/content/docs/reference/faq.md
+++ b/site/src/content/docs/reference/faq.md
@@ -13,7 +13,7 @@ Frequently asked questions about APEX.
 
 :::note[How do I get started?]
 Create your own repository from the
-[Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
+[Accelerator template](https://github.com/jonathan-vella/apex-accelerator)
 — click **"Use this template"** on GitHub, clone your new repo, and open it in the dev
 container. See the [Quickstart](../../getting-started/quickstart/) for the step-by-step guide.
 :::
@@ -154,7 +154,7 @@ The Orchestrator supports session resume via the `apex-recall` CLI. To resume:
     See the [Quickstart](../../getting-started/quickstart/) for the full getting-started flow.
 
 :::note[Is there a guided hands-on exercise?]
-Yes — the [MicroHack](https://jonathan-vella.github.io/microhack-agentic-infraops/) is a
+Yes — the [MicroHack](https://microhack.apexops.pro/) is a
 hands-on, guided challenge where you build Azure infrastructure end-to-end using AI agents,
 from requirements to deployment. It includes structured exercises, guided prompts, and
 reference solutions for each of the 7 main workflow steps plus Step 3.5 Governance.

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -1,5 +1,5 @@
 /* APEX — Custom Starlight Theme
-   Ported from microhack-agentic-infraops, adapted for docs site.
+   Ported from apex-microhack, adapted for docs site.
    Dark-first design, Azure blue accent, custom typography. */
 
 :root {

--- a/tools/scripts/init-from-template.mjs
+++ b/tools/scripts/init-from-template.mjs
@@ -14,7 +14,7 @@ import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 const TEMPLATE_OWNER = "jonathan-vella";
-const TEMPLATE_REPO = "azure-agentic-infraops-accelerator";
+const TEMPLATE_REPO = "apex-accelerator";
 const TEMPLATE_SLUG = `${TEMPLATE_OWNER}/${TEMPLATE_REPO}`;
 const TEMPLATE_URL = `https://github.com/${TEMPLATE_SLUG}`;
 


### PR DESCRIPTION
Phase 4 cross-repo link cleanup after the apex / apex-accelerator / apex-microhack renames.

- Accelerator GitHub links -> apex-accelerator (README, AGENTS.md, Footer, docs, index, contributing, faq, dev-containers)
- MicroHack docs links -> https://microhack.apexops.pro
- init-from-template TEMPLATE_REPO -> apex-accelerator
- terminology-blocklist exclude pattern + attribution comments -> apex-microhack

Verified: site builds, all internal links valid.