### PR TITLE
chore: remove tfsec from tooling, validation, and docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,8 +23,7 @@
     },
     "ghcr.io/devcontainers/features/terraform:1": {
       "tflint": "none",
-      "terragrunt": "none",
-      "installTFsec": false
+      "terragrunt": "none"
     },
     "ghcr.io/devcontainers/features/go:1": {
       "version": "1.24.2"

--- a/.github/agents/_subagents/terraform-plan-subagent.agent.md
+++ b/.github/agents/_subagents/terraform-plan-subagent.agent.md
@@ -66,7 +66,7 @@ This subagent does not:
   `az login`.
 - Approve destructive operations on the parent's behalf — destroys and
   replaces are surfaced for explicit human approval.
-- Run `terraform validate` or `tfsec` (those belong to
+- Run `terraform validate` (belongs to
   `terraform-validate-subagent`).
   </scope_fencing>
 

--- a/.github/agents/_subagents/terraform-validate-subagent.agent.md
+++ b/.github/agents/_subagents/terraform-validate-subagent.agent.md
@@ -1,6 +1,6 @@
 ---
 name: terraform-validate-subagent
-description: "Terraform validation subagent. Runs lint (fmt -check, validate, tfsec) first, then code review (AVM-TF standards, naming, security baseline, RBAC, governance). Returns PASS/FAIL + APPROVED/NEEDS_REVISION/FAILED verdict."
+description: "Terraform validation subagent. Runs lint (fmt -check, validate) first, then code review (AVM-TF standards, naming, security baseline, RBAC, governance). Returns PASS/FAIL + APPROVED/NEEDS_REVISION/FAILED verdict."
 model: ["Claude Sonnet 4.6"]
 user-invocable: false
 disable-model-invocation: false
@@ -29,8 +29,8 @@ tools:
 # Terraform Validate Subagent
 
 <role>
-Validation subagent that runs `terraform fmt -check`, `terraform validate`,
-and `tfsec` against generated Terraform configurations, then reviews them
+Validation subagent that runs `terraform fmt -check` and `terraform
+validate` against generated Terraform configurations, then reviews them
 against AVM-TF standards, CAF naming, the security baseline, RBAC least
 privilege, and discovered governance constraints, returning a structured
 PASS/FAIL diagnostic and verdict for the parent IaC agent.
@@ -39,7 +39,7 @@ PASS/FAIL diagnostic and verdict for the parent IaC agent.
 <input_contract>
 The parent agent passes **artifact paths plus the explicit input fields
 documented below — never the artifact bodies inline**. Re-read Terraform
-source (`.tf`, `.tfvars`), tfsec output, or
+source (`.tf`, `.tfvars`) or
 `04-governance-constraints.json` from disk on demand with bounded
 `read_file` ranges, and consult `apex-recall show <project> --json` for
 decision/finding lookups. If a required input field is missing, fail
@@ -92,7 +92,6 @@ Lint Summary:
   Format Issues: {count}
   Validate Errors: {count}
   Validate Warnings: {count}
-  tfsec Findings: {count or "skipped"}
 
 Review Summary:
 {1-2 sentence overall assessment}
@@ -136,7 +135,7 @@ to Planner; AVM-TF property gap → return to Planner + 04g-Governance.
 Before composing findings:
 
 1. Read every `.tf` and `.tfvars` file under the supplied module path.
-2. Re-read the `terraform fmt`, `terraform validate`, and `tfsec` console
+2. Re-read the `terraform fmt` and `terraform validate` console
    output collected in Phase 1.
 3. Re-read `04-governance-constraints.json` (and `.md` envelope when
    present) for the project, plus the relevant `azure-defaults` digest
@@ -186,8 +185,6 @@ not guess defaults.
    cd {module_path} && \
      { [ -d .terraform ] || terraform init -backend=false; } && \
      terraform validate
-   command -v tfsec && tfsec {module_path} || \
-     echo "TFSEC_SKIP: tfsec not installed"
    ```
 
 2. **Timeout-retry policy (Wave 1+)**: if `terraform init`,
@@ -220,9 +217,6 @@ not guess defaults.
 | Warnings only                     | PASS        | Proceed; note warnings     |
 | Format issues only (`fmt -check`) | FAIL        | Skip Phase 2, verdict FAIL |
 | `terraform validate` errors       | FAIL        | Skip Phase 2, verdict FAIL |
-| tfsec HIGH/CRITICAL findings      | FAIL        | Skip Phase 2, verdict FAIL |
-| tfsec MEDIUM/LOW findings         | PASS        | Proceed; note findings     |
-| tfsec not installed               | PASS        | Format + validate passed   |
 
 ### Phase 2 — Code review
 

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -7,7 +7,10 @@
     "azure-pricing": {
       "type": "stdio",
       "command": "${workspaceFolder}/tools/mcp-servers/azure-pricing/.venv/bin/python",
-      "args": ["-m", "azure_pricing_mcp"],
+      "args": [
+        "-m",
+        "azure_pricing_mcp"
+      ],
       "cwd": "${workspaceFolder}/tools/mcp-servers/azure-pricing/src",
       "env": {
         "AZURE_PRICING_HTTP_POOL_SIZE": "20",
@@ -19,7 +22,11 @@
     "terraform": {
       "type": "stdio",
       "command": "/go/bin/terraform-mcp-server",
-      "args": ["stdio", "--toolsets", "registry"],
+      "args": [
+        "stdio",
+        "--toolsets",
+        "registry"
+      ],
       "env": {}
     },
     "astro-docs": {
@@ -29,7 +36,13 @@
     "drawio": {
       "type": "stdio",
       "command": "deno",
-      "args": ["run", "-P", "--no-check", "--frozen", "${workspaceFolder}/tools/mcp-servers/drawio/src/index.ts"],
+      "args": [
+        "run",
+        "-P",
+        "--no-check",
+        "--frozen",
+        "${workspaceFolder}/tools/mcp-servers/drawio/src/index.ts"
+      ],
       "env": {
         "DENO_DIR": "${userHome}/.cache/deno"
       }
@@ -37,7 +50,12 @@
     "azure-mcp": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@azure/mcp@latest", "server", "start"]
+      "args": [
+        "-y",
+        "@azure/mcp@latest",
+        "server",
+        "start"
+      ]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-agentic-infraops",
+  "name": "apex",
   "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,

--- a/site/public/architecture-explorer-graph.json
+++ b/site/public/architecture-explorer-graph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../tools/schemas/explorer-graph.schema.json",
-  "generatedAt": "2026-06-08T13:09:34.547Z",
+  "generatedAt": "2026-06-08T13:59:33.577Z",
   "categories": [
     {
       "id": "agent",
@@ -619,7 +619,7 @@
       "id": "subagent:terraform-validate-subagent",
       "category": "subagent",
       "label": "terraform-validate-subagent",
-      "description": "Terraform validation subagent. Runs lint (fmt -check, validate, tfsec) first, then code review (AVM-TF standards, naming, security baseline, RBAC, governance). Returns PASS/FAIL + APPROVED/NEEDS_REVISION/FAILED verdict.",
+      "description": "Terraform validation subagent. Runs lint (fmt -check, validate) first, then code review (AVM-TF standards, naming, security baseline, RBAC, governance). Returns PASS/FAIL + APPROVED/NEEDS_REVISION/FAILED verdict.",
       "path": ".github/agents/_subagents/terraform-validate-subagent.agent.md",
       "links": {
         "source": "https://github.com/jonathan-vella/apex/blob/main/.github/agents/_subagents/terraform-validate-subagent.agent.md"

--- a/site/src/content/docs/getting-started/dev-containers.md
+++ b/site/src/content/docs/getting-started/dev-containers.md
@@ -236,7 +236,7 @@ The Dev Container includes:
 | Category               | Tools                                                                    |
 | ---------------------- | ------------------------------------------------------------------------ |
 | **Azure**              | Azure CLI 2.50+, Bicep CLI 0.30+, Azure Pricing MCP                      |
-| **Terraform**          | Terraform (latest), tfsec, HashiCorp Terraform MCP Server                |
+| **Terraform**          | Terraform (latest), HashiCorp Terraform MCP Server                       |
 | **PowerShell**         | PowerShell 7+, Az modules                                                |
 | **Python**             | Python 3.14, diagrams library, graphviz                                  |
 | **Node.js**            | Node LTS+, npm, markdownlint                                             |

--- a/tools/registry/tool-version-pins.json
+++ b/tools/registry/tool-version-pins.json
@@ -21,12 +21,6 @@
       "min": "20.0.0",
       "check_cmd": "node --version",
       "parser": "node"
-    },
-    "tfsec": {
-      "min": "1.28.0",
-      "check_cmd": "tfsec --version",
-      "parser": "tfsec",
-      "optional": true
     }
   }
 }

--- a/tools/schemas/iac-handoff.schema.json
+++ b/tools/schemas/iac-handoff.schema.json
@@ -71,7 +71,7 @@
         },
         "tool_versions": {
           "type": "object",
-          "description": "Pinned tool versions used for validate (bicep, terraform, az, tfsec, etc.)",
+          "description": "Pinned tool versions used for validate (bicep, terraform, az, node, etc.)",
           "additionalProperties": { "type": "string" }
         },
         "validate_gate": {

--- a/tools/scripts/validate-tool-versions.mjs
+++ b/tools/scripts/validate-tool-versions.mjs
@@ -3,7 +3,7 @@
  * Tool Version Pin Validator
  *
  * Asserts the dev container + CI environment runs the minimum required
- * versions of bicep, terraform, az, tfsec, and node. Mismatches block
+ * versions of bicep, terraform, az, and node. Mismatches block
  * Step 5 validation/Step 6 deploy because earlier versions miss the
  * built-in diagnostics path (bicep ≥ 0.21.0 for readEnvironmentVariable)
  * and AVM-TF v0.3+ semantics.
@@ -35,7 +35,6 @@ const DEFAULT_PINS = {
     terraform: { min: "1.6.0", check_cmd: "terraform version -json", parser: "terraform-json" },
     az: { min: "2.55.0", check_cmd: "az version --output json", parser: "az-json" },
     node: { min: "20.0.0", check_cmd: "node --version", parser: "node" },
-    tfsec: { min: "1.28.0", check_cmd: "tfsec --version", parser: "tfsec", optional: true },
   },
 };
 
@@ -87,10 +86,6 @@ function runVersion(cmd, parser) {
   }
   if (parser === "node") {
     const m = out.match(/v(\d+\.\d+\.\d+)/);
-    return m ? { ok: true, version: m[1] } : { ok: false, error: out.slice(0, 80) };
-  }
-  if (parser === "tfsec") {
-    const m = out.match(/(\d+\.\d+\.\d+)/);
     return m ? { ok: true, version: m[1] } : { ok: false, error: out.slice(0, 80) };
   }
   return { ok: false, error: `unknown parser: ${parser}` };


### PR DESCRIPTION
## Summary

Removes `tfsec` across the repo. It is deprecated (merged into Trivy) and was an optional, uninstalled tool pin that produced a dev-container tool-pin warning.

## Changes

- **tool-version-pins.json** — drop the `tfsec` pin block.
- **validate-tool-versions.mjs** — remove the default pin, `tfsec` parser branch, and header comment.
- **terraform-validate-subagent** — remove `tfsec` from description, role, contracts, Phase 1 lint command, and classification table (security baseline stays covered by Phase 2 review).
- **terraform-plan-subagent** — drop `tfsec` from the scope fence.
- **devcontainer.json** — remove `installTFsec: false` from the Terraform feature.
- **iac-handoff.schema.json** + **dev-containers.md** — remove doc/schema mentions.
- **architecture-explorer-graph.json** — regenerated.

## Validation

- `validate-tool-versions` ✅ (now checks bicep/terraform/az/node, 0 warnings)
- `validate:agents` ✅
- `validate-explorer-graph` ✅
- `lint:json` ✅