### PR TITLE
fix(scripts): fileExists rejects directories (addresses PR #469 review)

### DIFF
--- a/tools/scripts/_lib/e2e-helpers.mjs
+++ b/tools/scripts/_lib/e2e-helpers.mjs
@@ -39,7 +39,8 @@ export function detectIacTool(outputDir) {
  */
 export function fileExists(filePath) {
   try {
-    return fs.statSync(filePath).size > 0;
+    const st = fs.statSync(filePath);
+    return st.isFile() && st.size > 0;
   } catch {
     return false;
   }

--- a/tools/tests/lib/e2e-helpers.test.mjs
+++ b/tools/tests/lib/e2e-helpers.test.mjs
@@ -54,4 +54,8 @@ describe("_lib/e2e-helpers fileExists", () => {
   it("returns false for a missing path", () => {
     assert.equal(fileExists(path.join(tmpDir(), "nope.txt")), false);
   });
+
+  it("returns false for a directory path (file-only contract)", () => {
+    assert.equal(fileExists(tmpDir()), false);
+  });
 });


### PR DESCRIPTION
## Summary

Addresses the two Copilot review comments on the now-merged #469.

**Medium** — `fileExists` JSDoc documents a non-empty *file* check, but the implementation only tested `statSync(...).size > 0`, which can be non-zero for directories on some filesystems. Added an explicit `st.isFile()` guard so behavior matches the documented contract.

```diff
-    return fs.statSync(filePath).size > 0;
+    const st = fs.statSync(filePath);
+    return st.isFile() && st.size > 0;
```

**Low** — added a regression test asserting `fileExists(dir) === false`.

## Safety

The extracted helper is only used by `benchmark-e2e` and `validate-e2e-step`, and **all** call sites pass concrete artifact file paths (`main.tf`, `main.bicep`, `*.drawio`, `*.py`, `*.md`, `00-session-state.json`) — none pass a directory expecting `true`. The separate `fileExists` helpers in `validate-governance-refs` / `validate-instruction-checks` are unrelated (local `fs.existsSync`, accept directories by design).

## Validation

- `npm run test:lib-e2e` → 8/8 (adds the directory case)
- `npm run lint:js:ci` → clean
- `validate-e2e-step all` still emits valid JSON; `benchmark-e2e` syntax OK
- Pre-commit (prettier, eslint, gitleaks) → pass