### PR TITLE
fix(ci): Grant pull-requests read so gitleaks scans automation PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ jobs:
   ci:
     name: ci
     runs-on: ubuntu-latest
+    # gitleaks-action enumerates a PR's commits through the GitHub API on
+    # pull_request events. On automation PRs (e.g. Dependabot) the default
+    # GITHUB_TOKEN is read-only and omits the pull-requests scope, so that
+    # commit lookup returns 403 and the scan fails for every bot PR. A
+    # job-level permissions block overrides the workflow-level
+    # `contents: read`, so contents must be re-declared alongside the
+    # pull-requests grant the action needs.
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

The `gitleaks` step in `ci.yml` fails with a **403 on all automation PRs**
(e.g. Dependabot) — secret scanning never runs on those PRs.

## Root cause

`gitleaks/gitleaks-action@v3` enumerates a PR's commits through the GitHub
API on `pull_request` events (and can post PR comments). That call needs
the `pull-requests` token scope. The workflow only declares:

```yaml
permissions:
  contents: read
```

On automation PRs the default `GITHUB_TOKEN` is read-only and omits the
`pull-requests` scope entirely, so the commit lookup returns `403` and the
scan fails for every bot PR.

## Fix

Grant `pull-requests: read` at the **`ci` job** level. Because a job-level
`permissions` block fully overrides the workflow-level one, `contents: read`
is re-declared alongside it. Scope stays least-privilege — the
`external-tests` job is untouched and keeps inheriting the workflow default.

```yaml
jobs:
  ci:
    permissions:
      contents: read
      pull-requests: read
```

This is the minimal scope the action needs to read PR commits — not a
workaround (no switch to the CLI, no broadening of the whole workflow).

## Validation

- `actionlint .github/workflows/ci.yml` → PASS
- `yamllint -c .yamllint.yml .github/workflows/ci.yml` → PASS
- Parsed resolved permissions: `ci` → `{contents: read, pull-requests: read}`;
  `external-tests` → unchanged (inherits workflow default).
- Reproduced the failing API path against a real Dependabot PR:
  `GET /repos/{owner}/{repo}/pulls/{n}/commits` succeeds with a
  `pull-requests`-read token — the same call the action makes.

> Note: this fixes the **read** 403 that blocks automation PRs. PR
> *commenting* on findings would additionally need `pull-requests: write`,
> but that is an enhancement and Dependabot-triggered runs are read-only
> regardless.
