### PR TITLE
ci: Unblock accelerator upstream-sync PR failures

### DIFF
--- a/.github/workflows/branch-enforcement.yml
+++ b/.github/workflows/branch-enforcement.yml
@@ -27,9 +27,11 @@ jobs:
           # ``dependabot/...`` is reserved by GitHub for Dependabot-authored
           # PRs and cannot be renamed; allow the prefix unconditionally so
           # version-bump PRs aren't blocked by branch naming.
-          ALLOWED="^(docs|agents|skills|infra|scripts|instructions|fix|chore|feat|ci|refactor|perf|test|build|revert|dependabot)/"
+          # ``automation/...`` is the accelerator upstream-sync bot branch
+          # (automation/upstream-sync); allow it so weekly sync PRs pass.
+          ALLOWED="^(docs|agents|skills|infra|scripts|instructions|fix|chore|feat|ci|refactor|perf|test|build|revert|dependabot|automation)/"
           if [[ ! "$BRANCH" =~ $ALLOWED ]]; then
-            echo "::error::Branch '$BRANCH' does not follow naming convention. Use an approved prefix: docs/, agents/, skills/, infra/, scripts/, instructions/, fix/, feat/, chore/, ci/, refactor/, perf/, test/, build/, revert/, dependabot/"
+            echo "::error::Branch '$BRANCH' does not follow naming convention. Use an approved prefix: docs/, agents/, skills/, infra/, scripts/, instructions/, fix/, feat/, chore/, ci/, refactor/, perf/, test/, build/, revert/, dependabot/, automation/"
             exit 1
           fi
           echo "✅ Branch '$BRANCH' follows naming convention"
@@ -51,7 +53,7 @@ jobs:
 
           # Cross-cutting prefixes are exempt
           case "$PREFIX" in
-            feat|fix|chore|refactor|revert|perf|test|build|ci|dependabot)
+            feat|fix|chore|refactor|revert|perf|test|build|ci|dependabot|automation)
               echo "ℹ️  Branch prefix '$PREFIX/' is cross-cutting — no file scope restriction"
               exit 0
               ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,6 @@ jobs:
   ci:
     name: ci
     runs-on: ubuntu-latest
-    # gitleaks-action enumerates a PR's commits through the GitHub API on
-    # pull_request events. On automation PRs (e.g. Dependabot) the default
-    # GITHUB_TOKEN is read-only and omits the pull-requests scope, so that
-    # commit lookup returns 403 and the scan fails for every bot PR. A
-    # job-level permissions block overrides the workflow-level
-    # `contents: read`, so contents must be re-declared alongside the
-    # pull-requests grant the action needs.
-    permissions:
-      contents: read
-      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -45,16 +35,13 @@ jobs:
       - name: Install bats
         run: sudo apt-get install -y bats
 
-      - name: Scan for secrets (gitleaks)
-        uses: gitleaks/gitleaks-action@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # gitleaks-action@v2 still ships as a Node 20 action. Opt into the
-          # Node 24 runtime now so the deprecation auto-flip on 2026-06-02
-          # doesn't surprise CI. See:
-          # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
+      # Secret scanning runs as a pre-commit hook (lefthook `secrets-baseline`,
+      # gitleaks CLI), not in CI. The gitleaks GitHub Action 403s in two common
+      # cases: organization-owned repos need a paid license, and on automation/
+      # bot PRs the read-only GITHUB_TOKEN lacks the pull-requests scope the
+      # action uses to enumerate commits. Both break accelerator-derived repos,
+      # so we drop the action; the CLI is unlicensed and installed by
+      # .devcontainer/post-create.sh.
       - name: Lint Markdown
         run: npm run lint:md
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,29 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Secret scanning uses the gitleaks CLI, not gitleaks-action: the Action
+      # needs a paid license for organization-owned repos and enumerates a PR's
+      # commits through the GitHub API, so it 403s on accelerator-derived repos.
+      # The CLI is unlicensed, makes no API calls, and needs no extra token
+      # permissions. Scans full history (checkout above sets fetch-depth: 0) and
+      # honors the repo's .gitleaks.toml / .gitleaksignore. Server-side backstop
+      # for the lefthook `secrets-baseline` pre-commit hook (covers --no-verify
+      # bypasses, missing hooks, and GitHub-UI commits).
+      - name: Scan for secrets (gitleaks CLI)
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+          gitleaks git . --redact --no-banner
+
       - name: Setup Node
         uses: ./.github/actions/setup-node-repo
 
       - name: Install bats
         run: sudo apt-get install -y bats
 
-      # Secret scanning runs as a pre-commit hook (lefthook `secrets-baseline`,
-      # gitleaks CLI), not in CI. The gitleaks GitHub Action 403s in two common
-      # cases: organization-owned repos need a paid license, and on automation/
-      # bot PRs the read-only GITHUB_TOKEN lacks the pull-requests scope the
-      # action uses to enumerate commits. Both break accelerator-derived repos,
-      # so we drop the action; the CLI is unlicensed and installed by
-      # .devcontainer/post-create.sh.
       - name: Lint Markdown
         run: npm run lint:md
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -227,7 +227,7 @@ pre-commit:
         if command -v gitleaks >/dev/null 2>&1; then
           gitleaks protect --staged --redact --no-banner
         else
-          echo "⚠️  gitleaks not installed — skipping secret scan (CI will enforce)"
+          echo "⚠️  gitleaks not installed — secret scan skipped. Install gitleaks (see .devcontainer/post-create.sh) to enable."
         fi
       fail_text: |
         ❌ Secrets detected in staged files!

--- a/site/src/content/docs/guides/hooks.md
+++ b/site/src/content/docs/guides/hooks.md
@@ -45,10 +45,10 @@ sequenceDiagram
 | `subagent-validation/` | SubagentStop | Validate subagent output quality (advisory) |     15s |
 
 The suite is intentionally small and high-signal. Secret scanning is handled by
-**gitleaks** (pre-commit via lefthook + CI via the gitleaks action), not by an
-agent hook. Earlier `secrets-scanner`, `session-telemetry`, and `tool-audit`
-hooks were removed: the first duplicated gitleaks, and the latter two only wrote
-logs that nothing consumed.
+**gitleaks** as a pre-commit hook (via lefthook), not by an agent hook or in CI.
+Earlier `secrets-scanner`, `session-telemetry`, and `tool-audit` hooks were
+removed: the first duplicated gitleaks, and the latter two only wrote logs that
+nothing consumed.
 
 ## Configuration
 
@@ -118,9 +118,10 @@ parsing and emission in one `python3` process.
 
 ### Secret Scanning (handled by gitleaks, not a hook)
 
-Secrets are caught by **gitleaks** at two independent layers — pre-commit (via
-lefthook, soft-skips locally if gitleaks is missing) and CI (the gitleaks action,
-hard-fail). There is no agent hook for secret scanning; a former bespoke
+Secrets are caught by **gitleaks** at the pre-commit layer (via lefthook,
+soft-skips locally if gitleaks is missing). CI no longer runs the gitleaks
+action — it requires a paid license for organization-owned repos and returns 403
+without one. There is no agent hook for secret scanning; a former bespoke
 regex-based `secrets-scanner` was removed because it duplicated gitleaks with a
 weaker ruleset.
 

--- a/site/src/content/docs/guides/hooks.md
+++ b/site/src/content/docs/guides/hooks.md
@@ -45,10 +45,10 @@ sequenceDiagram
 | `subagent-validation/` | SubagentStop | Validate subagent output quality (advisory) |     15s |
 
 The suite is intentionally small and high-signal. Secret scanning is handled by
-**gitleaks** as a pre-commit hook (via lefthook), not by an agent hook or in CI.
-Earlier `secrets-scanner`, `session-telemetry`, and `tool-audit` hooks were
-removed: the first duplicated gitleaks, and the latter two only wrote logs that
-nothing consumed.
+**gitleaks** (pre-commit via lefthook + CI via the gitleaks CLI in `ci.yml`),
+not by an agent hook. Earlier `secrets-scanner`, `session-telemetry`, and
+`tool-audit` hooks were removed: the first duplicated gitleaks, and the latter
+two only wrote logs that nothing consumed.
 
 ## Configuration
 
@@ -118,12 +118,13 @@ parsing and emission in one `python3` process.
 
 ### Secret Scanning (handled by gitleaks, not a hook)
 
-Secrets are caught by **gitleaks** at the pre-commit layer (via lefthook,
-soft-skips locally if gitleaks is missing). CI no longer runs the gitleaks
-action — it requires a paid license for organization-owned repos and returns 403
-without one. There is no agent hook for secret scanning; a former bespoke
-regex-based `secrets-scanner` was removed because it duplicated gitleaks with a
-weaker ruleset.
+Secrets are caught by **gitleaks** at two independent layers — pre-commit (via
+lefthook, soft-skips locally if gitleaks is missing) and CI (the gitleaks CLI in
+`ci.yml`, hard-fail). CI runs the CLI rather than gitleaks-action because the
+Action needs a paid license for organization-owned repos and 403s on bot PRs.
+There is no agent hook for secret scanning; a former bespoke regex-based
+`secrets-scanner` was removed because it duplicated gitleaks with a weaker
+ruleset.
 
 ## Hook Directory Structure
 

--- a/site/src/content/docs/reference/validation-reference.md
+++ b/site/src/content/docs/reference/validation-reference.md
@@ -183,7 +183,7 @@ All workflows are in `.github/workflows/`.
 
 | Workflow                  | File                            | Trigger                      | Purpose                                                                                            |
 | ------------------------- | ------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------- |
-| CI                        | `ci.yml`                        | PR to `main`, push to `main` | Full validation suite (markdown, Prettier, agents, skills, hooks, bats tests, MCP, VS Code config) + Python ruff in the external-tests job |
+| CI                        | `ci.yml`                        | PR to `main`, push to `main` | Full validation suite (markdown, Prettier, agents, skills, hooks, gitleaks CLI, bats tests, MCP, VS Code config) + Python ruff in the external-tests job |
 | IaC Checks                | `iac-checks.yml`                | `infra/**` changes           | Terraform fmt/validate + Bicep format (path-filtered; no-op until IaC is committed)                |
 | Branch Enforcement        | `branch-enforcement.yml`        | PR to `main`                 | Branch naming convention and scope validation                                                      |
 | Link Check                | `link-check.yml`                | Docs changes                 | URL validity in documentation                                                                      |

--- a/site/src/content/docs/reference/validation-reference.md
+++ b/site/src/content/docs/reference/validation-reference.md
@@ -183,7 +183,7 @@ All workflows are in `.github/workflows/`.
 
 | Workflow                  | File                            | Trigger                      | Purpose                                                                                            |
 | ------------------------- | ------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------- |
-| CI                        | `ci.yml`                        | PR to `main`, push to `main` | Full validation suite (markdown, Prettier, agents, skills, hooks, gitleaks, bats tests, MCP, VS Code config) + Python ruff in the external-tests job |
+| CI                        | `ci.yml`                        | PR to `main`, push to `main` | Full validation suite (markdown, Prettier, agents, skills, hooks, bats tests, MCP, VS Code config) + Python ruff in the external-tests job |
 | IaC Checks                | `iac-checks.yml`                | `infra/**` changes           | Terraform fmt/validate + Bicep format (path-filtered; no-op until IaC is committed)                |
 | Branch Enforcement        | `branch-enforcement.yml`        | PR to `main`                 | Branch naming convention and scope validation                                                      |
 | Link Check                | `link-check.yml`                | Docs changes                 | URL validity in documentation                                                                      |

--- a/tools/scripts/lint-docs-frontmatter.mjs
+++ b/tools/scripts/lint-docs-frontmatter.mjs
@@ -7,6 +7,7 @@
  *
  * Exits non-zero on the first failure category. Intended for `npm run lint:docs-frontmatter`.
  */
+import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -41,6 +42,12 @@ function parseFrontmatter(src) {
 }
 
 async function main() {
+  // Accelerator-derived repos exclude site/ from the upstream sync, so the
+  // docs tree may not exist. Skip cleanly instead of throwing ENOENT.
+  if (!existsSync(DOCS_ROOT)) {
+    console.log(`✔ no docs site at ${path.relative(REPO_ROOT, DOCS_ROOT)} — frontmatter lint skipped.`);
+    return;
+  }
   const files = await walk(DOCS_ROOT, []);
   const issues = [];
   for (const file of files) {

--- a/tools/scripts/sync-workflows.mjs
+++ b/tools/scripts/sync-workflows.mjs
@@ -31,8 +31,12 @@ const WORKFLOWS_DIR = ".github/workflows";
 const SKIP_FILES = new Set([
   // Accelerator-only
   "weekly-upstream-sync.yml",
-  // Upstream-only (docs site, link-check, e2e tests, sensei branch lifecycle)
+  // Upstream-only (docs site, link-check, e2e tests, sensei branch lifecycle).
+  // The accelerator sync excludes site/, so every docs-site workflow would fail
+  // in consumer repos (no site/src/content/docs to lint or build).
   "docs.yml",
+  "docs-checks.yml",
+  "docs-gardening.yml",
   "link-check.yml",
   "e2e-validation.yml",
   "sensei-branch-maintenance.yml",


### PR DESCRIPTION
## What

Fixes so **accelerator-derived repos** pass the weekly `automation/upstream-sync` PR, plus a follow-on to #488.

| Issue | Root cause | Fix |
| --- | --- | --- |
| Branch-naming check fails | Sync bot uses branch `automation/upstream-sync`; `automation/` not in the allowlist | Allow `automation/` in the naming allowlist + cross-cutting scope list (`branch-enforcement.yml`) |
| `lint-docs-frontmatter.mjs` errors | Consumer repos exclude `site/`, so `site/src/content/docs` is missing → `ENOENT` | Exit 0 with a skip message when the docs tree is absent (`lint-docs-frontmatter.mjs`) |
| Docs workflows shipped to consumers | `sync:workflows` pulled `docs-checks.yml` / `docs-gardening.yml` into repos with no `site/` | Add both to `SKIP_FILES` (`sync-workflows.mjs`) |
| gitleaks 403 | gitleaks-action 403s for org-owned repos (needs a paid license) **and** on bot PRs (read-only token lacks the `pull-requests` scope) | Replace the Action with the **gitleaks CLI** in `ci.yml` — no license, no GitHub API calls, no extra permissions → no 403, and works for org-owned consumer repos |

## Secret scanning: CLI, not the Action (re: #488 + review)

#488 fixed the 403 by granting `pull-requests: read` so the Action could scan bot PRs. This PR instead drops the Action (and its now-orphaned job-level `permissions` block) and runs the **gitleaks CLI** in CI:

- Pinned to gitleaks `8.30.1`, scans git history with the repo's `.gitleaks.toml` / `.gitleaksignore`, needs no token permissions and makes no API calls — sidestepping both the org-license 403 and the bot-PR 403.
- The lefthook `secrets-baseline` pre-commit hook stays for fast local feedback; CI is the server-side backstop for `--no-verify`, missing hooks, and GitHub-UI commits (per review feedback).
- The "CI still scans via `ci.yml`" comments in `sensei-branch-maintenance.yml`, `weekly-maintenance.yml`, and `governance-policy-baseline.yml` remain accurate, so they're unchanged.

## Notes

- Docs updated to the two-layer model (pre-commit + CI, both gitleaks CLI): `hooks.md`, `validation-reference.md`.
- Workflow files aren't auto-synced — consumers pick up `branch-enforcement.yml` / `ci.yml` via `npm run sync:workflows`. `tools/` + `lefthook.yml` flow through the weekly sync automatically.
- Existing consumer repos that already received `docs-checks.yml` must delete it once (the `SKIP_FILES` change only prevents re-adding it).
