### PR TITLE
docs: update JSDoc return type for parseJsonc function

### DIFF
--- a/tools/scripts/_lib/parse-jsonc.mjs
+++ b/tools/scripts/_lib/parse-jsonc.mjs
@@ -5,7 +5,7 @@
  * Handles devcontainer.json and other VS Code config formats.
  *
  * @param {string} content - Raw JSONC file content
- * @returns {any} Parsed JSON object
+ * @returns {object|string|number|boolean|null} Parsed JSON object
  */
 export function parseJsonc(content) {
   // Remove block comments /* ... */


### PR DESCRIPTION
### 问题背景
原始 JSDoc 中，`parseJsonc` 函数的返回类型标注为 'any'。虽然 `JSON.parse` 返回 `any`，但更精确的类型注解可以增强文档清晰度，并在使用 TypeScript 或静态分析时提升类型安全性和工具支持。

### 修改内容
- 修改了 `parseJsonc` 函数的 JSDoc 注释中的 `@returns` 标签。
- 将 `@returns {any} Parsed JSON object` 更新为 `@returns {object|string|number|boolean|null} Parsed JSON object`。
- 为什么这样改：提供更准确的类型信息，改善文档质量，支持更好的类型检查和代码分析，而不影响运行时行为。
- 对代码质量/性能/安全性的提升：无直接影响，但提高了代码的可读性、维护性和开发体验。

### 验证方式
- 这是一个纯文档修改，不影响函数逻辑或运行时行为。
- 现有测试应继续通过，因为未更改代码功能。
- 可以手动验证 JSDoc 注释的更新是否正确显示在文档或编辑器工具提示中。

### 其他信息
- 是否有 breaking changes：无，仅更新注释，不改变 API 或行为。
- 是否需要更新文档：不适用，此 PR 本身就是文档更新。
- 是否有已知的限制：无。