### PR TITLE
chore: drop dead baseline gitignore exceptions and doc ref

### DIFF
--- a/.github/skills/context-management/references/log-profiling.md
+++ b/.github/skills/context-management/references/log-profiling.md
@@ -63,10 +63,10 @@ done > agent-output/_baselines/profile-runs.jsonl
 ```
 
 Compute p50 / p90 / max manually (or with `jq`) across the sessions
-for each headline metric and commit the result as
-`agent-output/_baselines/multi-log-baseline.json`. The token-reduction
-plan locks targets against the **p50** of that range, never the
-canonical `test04-01` outlier alone.
+for each headline metric and save the result locally as
+`agent-output/_baselines/multi-log-baseline.json` (gitignored working
+data). The token-reduction plan locks targets against the **p50** of
+that range, never the canonical `test04-01` outlier alone.
 
 ## Tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -98,14 +98,6 @@ freshness-report.json
 # Use a contents-only ignore (rather than the directory itself) so
 # that single committed deliverables can be re-included with `!`.
 agent-output/_baselines/*
-# Exception: the multi-log token-reduction baseline is a canonical
-# deliverable (Plan 01 Phase 0) — keep it tracked.
-!agent-output/_baselines/multi-log-baseline.json
-# Exception: Plan 01 Phase 4 body-compression baseline + target
-# hypotheses — canonical PR-visible deliverable for the body
-# compression workstream.
-!agent-output/_baselines/phase4-body-baseline.json
-!agent-output/_baselines/phase4-body-targets.json
 
 # Draw.io quality bench runs (working data; commit only the canonical
 # baseline at tools/tests/drawio-baseline/regen-baseline.json)


### PR DESCRIPTION
Follow-up to #498 (which removed the three `agent-output/_baselines/*` baseline files). Cleans up now-dangling references:

- Removes the 3 dead `!` un-ignore entries (and their comment blocks) in `.gitignore`
- Updates `log-profiling.md` to describe the baseline as gitignored local working data instead of a committed file

`CHANGELOG.md` is left untouched (historical record).
