### PR TITLE
fix(scripts): support js-yaml 5.x ESM via namespace import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint-formatter-compact": "^9.0.1",
         "eslint-plugin-n": "^18.1.0",
         "fast-xml-parser": "^5.9.3",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^5.1.0",
         "jsdom": "^29.1.1",
         "lefthook": "^2.1.8",
         "markdown-link-check": "^3.14.2",
@@ -1408,6 +1408,29 @@
         "@types/node": "*",
         "cosmiconfig": ">=9",
         "typescript": ">=5"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-spawn": {
@@ -2813,9 +2836,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.1.0.tgz",
+      "integrity": "sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==",
       "dev": true,
       "funding": [
         {
@@ -2832,7 +2855,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsdom": {
@@ -5122,6 +5145,29 @@
       },
       "engines": {
         "node": ">=20.0"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "eslint-formatter-compact": "^9.0.1",
     "eslint-plugin-n": "^18.1.0",
     "fast-xml-parser": "^5.9.3",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^5.1.0",
     "jsdom": "^29.1.1",
     "lefthook": "^2.1.8",
     "markdown-link-check": "^3.14.2",

--- a/tools/scripts/assess-agents.mjs
+++ b/tools/scripts/assess-agents.mjs
@@ -32,7 +32,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import yaml from "js-yaml";
+// Namespace import (not `import yaml from "js-yaml"`): js-yaml 5.x is pure ESM
+// and exposes named exports only — no default export. A namespace import works
+// under both js-yaml 4.x (CommonJS) and 5.x (ESM).
+import * as yaml from "js-yaml";
 
 import { getAgents } from "./_lib/workspace-index.mjs";
 import { getBody } from "./_lib/parse-frontmatter.mjs";

--- a/tools/scripts/validate-agents.mjs
+++ b/tools/scripts/validate-agents.mjs
@@ -14,7 +14,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import yaml from "js-yaml";
+// Namespace import (not `import yaml from "js-yaml"`): js-yaml 5.x is pure ESM
+// and exposes named exports only — no default export. A namespace import works
+// under both js-yaml 4.x (CommonJS) and 5.x (ESM).
+import * as yaml from "js-yaml";
 import { getAgents, getPromptFiles } from "./_lib/workspace-index.mjs";
 import { getBody } from "./_lib/parse-frontmatter.mjs";
 import { Reporter } from "./_lib/reporter.mjs";


### PR DESCRIPTION
## What

Make the agent validators compatible with **js-yaml 5.x**, then bump the root devDependency from `^4.1.1` to `^5.1.0`.

## Why

js-yaml 5.x ships as **pure ESM with named exports only** — it no longer provides a `default` export. The existing default import:

```js
import yaml from "js-yaml";
```

throws at module-link time under 5.x:

```
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
```

This is exactly the failure that breaks `ci/ci` (`npm run validate:agents`) the moment the js-yaml major bump lands. It was reproduced in isolation against js-yaml `5.1.0`.

## Change

Switch the two consumers to a **namespace import**, which works under both js-yaml 4.x (CommonJS) and 5.x (ESM):

```js
import * as yaml from "js-yaml";
```

- `tools/scripts/validate-agents.mjs`
- `tools/scripts/assess-agents.mjs`

Both only call `yaml.load(...)`, so call sites are unchanged.

## Validation

- `npm run validate:agents` → ✅ passes under js-yaml `5.1.0`
- `npm run assess:agents` → ✅ exit 0
- eslint (`--max-warnings=0`) + prettier → ✅ clean

## Note

This supersedes the Dependabot bump PR (which lacked the import fix and would have broken CI). It also carries the fix downstream via the accelerator template sync.
