### PR TITLE
ci: remove gitleaks CLI from CI (pre-commit only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,23 +29,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Secret scanning uses the gitleaks CLI, not gitleaks-action: the Action
-      # needs a paid license for organization-owned repos and enumerates a PR's
-      # commits through the GitHub API, so it 403s on accelerator-derived repos.
-      # The CLI is unlicensed, makes no API calls, and needs no extra token
-      # permissions. Scans full history (checkout above sets fetch-depth: 0) and
-      # honors the repo's .gitleaks.toml / .gitleaksignore. Server-side backstop
-      # for the lefthook `secrets-baseline` pre-commit hook (covers --no-verify
-      # bypasses, missing hooks, and GitHub-UI commits).
-      - name: Scan for secrets (gitleaks CLI)
-        env:
-          GITLEAKS_VERSION: "8.30.1"
-        run: |
-          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | sudo tar -xz -C /usr/local/bin gitleaks
-          gitleaks version
-          gitleaks git . --redact --no-banner
-
       - name: Setup Node
         uses: ./.github/actions/setup-node-repo
 

--- a/.github/workflows/governance-policy-baseline.yml
+++ b/.github/workflows/governance-policy-baseline.yml
@@ -22,7 +22,7 @@ concurrency:
 # script (`lefthook install`), which registers a pre-commit hook that calls
 # `gitleaks`. gitleaks is not installed on the GitHub-hosted runner, so the
 # create-pull-request commit fails with `gitleaks: not found`. Secrets
-# scanning still runs on every PR via ci.yml.
+# scanning is a local pre-commit hook only.
 env:
   LEFTHOOK: "0"
 

--- a/.github/workflows/sensei-branch-maintenance.yml
+++ b/.github/workflows/sensei-branch-maintenance.yml
@@ -37,7 +37,7 @@ concurrency:
 # script (`lefthook install`), which registers a pre-commit hook that calls
 # `gitleaks`. gitleaks is not installed on the GitHub-hosted runner, so the
 # main → sensei merge commit fails with `gitleaks: not found`. Secrets
-# scanning still runs on every PR via ci.yml.
+# scanning is a local pre-commit hook only.
 env:
   LEFTHOOK: "0"
 

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -36,7 +36,7 @@ concurrency:
 # script (`lefthook install`), which registers a pre-commit hook that calls
 # `gitleaks`. gitleaks is not installed on the GitHub-hosted runner, so any
 # automated `git commit` (e.g. peter-evans/create-pull-request) fails with
-# `gitleaks: not found`. Secrets scanning still runs on every PR via ci.yml.
+# `gitleaks: not found`. Secrets scanning is a local pre-commit hook only.
 env:
   LEFTHOOK: "0"
 

--- a/site/src/content/docs/guides/hooks.md
+++ b/site/src/content/docs/guides/hooks.md
@@ -45,8 +45,8 @@ sequenceDiagram
 | `subagent-validation/` | SubagentStop | Validate subagent output quality (advisory) |     15s |
 
 The suite is intentionally small and high-signal. Secret scanning is handled by
-**gitleaks** (pre-commit via lefthook + CI via the gitleaks CLI in `ci.yml`),
-not by an agent hook. Earlier `secrets-scanner`, `session-telemetry`, and
+**gitleaks** (pre-commit via lefthook), not by an agent hook. Earlier
+`secrets-scanner`, `session-telemetry`, and
 `tool-audit` hooks were removed: the first duplicated gitleaks, and the latter
 two only wrote logs that nothing consumed.
 
@@ -118,10 +118,8 @@ parsing and emission in one `python3` process.
 
 ### Secret Scanning (handled by gitleaks, not a hook)
 
-Secrets are caught by **gitleaks** at two independent layers — pre-commit (via
-lefthook, soft-skips locally if gitleaks is missing) and CI (the gitleaks CLI in
-`ci.yml`, hard-fail). CI runs the CLI rather than gitleaks-action because the
-Action needs a paid license for organization-owned repos and 403s on bot PRs.
+Secrets are caught by **gitleaks** at the pre-commit layer (via lefthook,
+soft-skips locally if gitleaks is missing). Secret scanning is not part of CI.
 There is no agent hook for secret scanning; a former bespoke regex-based
 `secrets-scanner` was removed because it duplicated gitleaks with a weaker
 ruleset.

--- a/site/src/content/docs/reference/validation-reference.md
+++ b/site/src/content/docs/reference/validation-reference.md
@@ -183,7 +183,7 @@ All workflows are in `.github/workflows/`.
 
 | Workflow                  | File                            | Trigger                      | Purpose                                                                                            |
 | ------------------------- | ------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------- |
-| CI                        | `ci.yml`                        | PR to `main`, push to `main` | Full validation suite (markdown, Prettier, agents, skills, hooks, gitleaks CLI, bats tests, MCP, VS Code config) + Python ruff in the external-tests job |
+| CI                     | `ci.yml`                        | PR to `main`, push to `main` | Full validation suite (markdown, Prettier, agents, skills, hooks, bats tests, MCP, VS Code config) + Python ruff in the external-tests job |
 | IaC Checks                | `iac-checks.yml`                | `infra/**` changes           | Terraform fmt/validate + Bicep format (path-filtered; no-op until IaC is committed)                |
 | Branch Enforcement        | `branch-enforcement.yml`        | PR to `main`                 | Branch naming convention and scope validation                                                      |
 | Link Check                | `link-check.yml`                | Docs changes                 | URL validity in documentation                                                                      |


### PR DESCRIPTION
Removes the gitleaks CLI secret-scan step from `ci.yml`; secret scanning runs solely as the lefthook `secrets-baseline` pre-commit hook. Updates workflow comments and docs (hooks guide, validation reference) to drop the CI-scanning claims.