### PR TITLE
docs: clarify gitleaks pre-commit-only scanning

### DIFF
--- a/.github/workflows/governance-policy-baseline.yml
+++ b/.github/workflows/governance-policy-baseline.yml
@@ -22,7 +22,7 @@ concurrency:
 # script (`lefthook install`), which registers a pre-commit hook that calls
 # `gitleaks`. gitleaks is not installed on the GitHub-hosted runner, so the
 # create-pull-request commit fails with `gitleaks: not found`. Secrets
-# scanning is a local pre-commit hook only.
+# scanning via gitleaks is a local pre-commit hook only.
 env:
   LEFTHOOK: "0"
 

--- a/.github/workflows/sensei-branch-maintenance.yml
+++ b/.github/workflows/sensei-branch-maintenance.yml
@@ -37,7 +37,7 @@ concurrency:
 # script (`lefthook install`), which registers a pre-commit hook that calls
 # `gitleaks`. gitleaks is not installed on the GitHub-hosted runner, so the
 # main → sensei merge commit fails with `gitleaks: not found`. Secrets
-# scanning is a local pre-commit hook only.
+# scanning via gitleaks is a local pre-commit hook only.
 env:
   LEFTHOOK: "0"
 

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -36,7 +36,7 @@ concurrency:
 # script (`lefthook install`), which registers a pre-commit hook that calls
 # `gitleaks`. gitleaks is not installed on the GitHub-hosted runner, so any
 # automated `git commit` (e.g. peter-evans/create-pull-request) fails with
-# `gitleaks: not found`. Secrets scanning is a local pre-commit hook only.
+# `gitleaks: not found`. Gitleaks secret scanning is a local pre-commit hook only.
 env:
   LEFTHOOK: "0"
 

--- a/site/src/content/docs/guides/hooks.md
+++ b/site/src/content/docs/guides/hooks.md
@@ -118,9 +118,11 @@ parsing and emission in one `python3` process.
 
 ### Secret Scanning (handled by gitleaks, not a hook)
 
-Secrets are caught by **gitleaks** at the pre-commit layer (via lefthook,
-soft-skips locally if gitleaks is missing). Secret scanning is not part of CI.
-There is no agent hook for secret scanning; a former bespoke regex-based
+Secrets are caught by **gitleaks** at the pre-commit layer (via lefthook). This
+scan soft-skips locally if `gitleaks` is missing, and gitleaks is not run in CI.
+Commits made with `--no-verify`, without lefthook installed, or via the GitHub
+UI will not be scanned. There is no agent hook for secret scanning; a former
+bespoke regex-based
 `secrets-scanner` was removed because it duplicated gitleaks with a weaker
 ruleset.
 


### PR DESCRIPTION
Applies the Copilot review feedback from #508: names gitleaks explicitly in the three workflow LEFTHOOK comments and calls out the bypass cases (--no-verify, missing lefthook, GitHub-UI commits) in the hooks guide so readers don't assume CI is a backstop.