### PR TITLE
fix(devcontainer): actually auto-update terraform-mcp-server on start

### DIFF
--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -16,21 +16,23 @@ fi
 
 # ─── Terraform MCP Server ────────────────────────────────────────────────────
 # Uses clone+build: go install rejects modules with replace directives in go.mod.
-if command -v terraform-mcp-server &>/dev/null || [ -x /go/bin/terraform-mcp-server ]; then
-    printf "    terraform-mcp-server  ✅ already installed — skipping\n"
-elif command -v go &>/dev/null; then
+# No version pin/tag — tracks upstream main. Rebuilds every start so the binary
+# stays current; only skips when Go is unavailable to rebuild.
+if command -v go &>/dev/null; then
     printf "    terraform-mcp-server  "
     TF_MCP_TMP=$(mktemp -d)
     if git clone --depth=1 --quiet https://github.com/hashicorp/terraform-mcp-server.git "$TF_MCP_TMP" 2>/dev/null; then
         pushd "$TF_MCP_TMP" > /dev/null
         go build -o /go/bin/terraform-mcp-server ./cmd/terraform-mcp-server/ 2>/dev/null \
-            && printf "✅ installed\n" \
-            || printf "⚠️  build failed (continuing)\n"
+            && printf "✅ rebuilt (latest)\n" \
+            || printf "⚠️  build failed — keeping existing binary, if any (continuing)\n"
         popd > /dev/null
     else
-        printf "⚠️  git clone failed (continuing)\n"
+        printf "⚠️  git clone failed — keeping existing binary, if any (continuing)\n"
     fi
     rm -rf "$TF_MCP_TMP"
+elif command -v terraform-mcp-server &>/dev/null || [ -x /go/bin/terraform-mcp-server ]; then
+    printf "    terraform-mcp-server  ✅ already installed (Go not found — cannot refresh)\n"
 else
     printf "    terraform-mcp-server  ⚠️  Go not found — skipping\n"
 fi


### PR DESCRIPTION
## Summary

`terraform-mcp-server` was stuck at whatever commit was checked out at first container creation — `post-start.sh` skipped the rebuild entirely whenever the binary already existed, contradicting the documented **"Auto-updates on start"** behavior in [dev-containers.md](site/src/content/docs/getting-started/dev-containers.md#L246-248).

Observed drift: local binary built 2026-06-12 (~v1.0.0), upstream `main` had since moved to `d020979c` (2026-06-24, "Add organization allowlist #386") — 18 days stale, and would have stayed stale indefinitely since the guard always took the "skip" branch.

## Fix

`post-start.sh` now always attempts a rebuild when Go is available (`git clone --depth=1` + `go build`), matching what `post-create.sh` already does. Falls back to the existing binary on clone/build failure, and only truly skips when Go itself is unavailable.

## Validation

- `npm run lint:safe-shell` — clean
- Manually rebuilt locally and confirmed the binary now reflects upstream commit `d020979c` (2026-06-24)
