### PR TITLE
fix(devcontainer): correct TFLint checksum filename so install succeeds

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -303,18 +303,23 @@ else
     TFLINT_ARCH=$(dpkg --print-architecture)
     if [ "$TFLINT_ARCH" = "amd64" ] || [ "$TFLINT_ARCH" = "arm64" ]; then
         TFLINT_TMP=$(mktemp -d)
-        TFLINT_URL="https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TFLINT_ARCH}.zip"
+        # Save the download under its published asset name (arch-derived, so
+        # both amd64 and arm64 hosts work). `sha256sum -c` resolves the file
+        # by the name recorded in checksums.txt, so a generic "tflint.zip"
+        # target fails the integrity check even when the bytes are correct.
+        TFLINT_ZIP="tflint_linux_${TFLINT_ARCH}.zip"
+        TFLINT_URL="https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/${TFLINT_ZIP}"
         TFLINT_SHA_URL="https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/checksums.txt"
-        if curl -fsSL "$TFLINT_URL" -o "$TFLINT_TMP/tflint.zip" \
+        if curl -fsSL "$TFLINT_URL" -o "$TFLINT_TMP/${TFLINT_ZIP}" \
             && curl -fsSL "$TFLINT_SHA_URL" -o "$TFLINT_TMP/checksums.txt" \
             && (cd "$TFLINT_TMP" && grep -E " tflint_linux_${TFLINT_ARCH}\.zip$" checksums.txt | sha256sum -c -) \
-            && unzip -o -q "$TFLINT_TMP/tflint.zip" -d "$TFLINT_TMP" \
+            && unzip -o -q "$TFLINT_TMP/${TFLINT_ZIP}" -d "$TFLINT_TMP" \
             && sudo install -m 0755 "$TFLINT_TMP/tflint" /usr/local/bin/tflint; then
             rm -rf "$TFLINT_TMP"
             step_done "TFLint $(tflint --version 2>/dev/null | head -1)"
         else
             rm -rf "$TFLINT_TMP"
-            step_warn "TFLint install failed — check network access to github.com"
+            step_warn "TFLint install failed — download or checksum verification error"
         fi
     else
         step_warn "TFLint skipped: unsupported architecture $TFLINT_ARCH (supported: amd64, arm64)"


### PR DESCRIPTION
## Problem

The TFLint install step in `post-create.sh` downloaded the release asset to a generic `tflint.zip`, but `checksums.txt` lists it under its published name `tflint_linux_<arch>.zip`. `sha256sum -c` resolves the file by the name in the checksum line, so verification failed with `No such file or directory` — even though the download succeeded. The misleading warning blamed network access.

## Fix

- Download under the arch-derived asset name via a new `TFLINT_ZIP="tflint_linux_${TFLINT_ARCH}.zip"` variable, used consistently for download, checksum, and unzip.
- Works on both **amd64 and arm64** (filename derived from `dpkg --print-architecture`, verified both assets + checksum lines exist).
- Corrected the warning text to "download or checksum verification error".

## Validation

- `bash -n` syntax check passes.
- Ran the corrected logic end-to-end: checksum verifies `OK`, TFLint 0.61.0 installs to `/usr/local/bin/tflint`.