### PR TITLE
chore(devcontainer): bump Go to 1.26 and TFLint to 0.63.1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
       "terragrunt": "none"
     },
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.24.2"
+      "version": "1.26"
     },
     "ghcr.io/devcontainers-community/features/deno": {
       "version": "latest"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -295,7 +295,7 @@ fi
 # IEEE_P1363 encoded signature"). We therefore set tflint=none in the feature
 # and install the pinned TFLint release directly here — no cosign required.
 
-TFLINT_VERSION="0.61.0"
+TFLINT_VERSION="0.63.1"
 step_start "🧹" "Installing TFLint v${TFLINT_VERSION} (cosign-free)..."
 if command -v tflint &>/dev/null && tflint --version 2>/dev/null | grep -q "$TFLINT_VERSION"; then
     step_done "TFLint v${TFLINT_VERSION} already installed"


### PR DESCRIPTION
## What

Version-currency bumps for two devcontainer tools that Dependabot doesn't track (feature *inputs* / hardcoded script pins, not feature digests):

- **Go** `1.24.2` → `1.26` (feature input in [devcontainer.json](.devcontainer/devcontainer.json)). Latest stable is 1.26.5; using the `1.26` minor so patch releases are picked up on rebuild. Only affects the `terraform-mcp-server` build.
- **TFLint** `0.61.0` → `0.63.1` (`TFLINT_VERSION` in [post-create.sh](.devcontainer/post-create.sh)).

## Why

Both were flagged as behind latest during a devcontainer currency review. They install into the Linux container regardless of host, so no cross-platform impact. The TFLint install path is arch-derived (amd64 + arm64) and unchanged here.

## Validation

- `devcontainer.json` parses clean (language server, no errors).
- TFLint 0.63.1 installed end-to-end via the script's own arch-derived logic: checksum `tflint_linux_amd64.zip: OK`, `TFLint version 0.63.1`.
- Both amd64 + arm64 release assets confirmed present for 0.63.1.