### PR TITLE
fix(vnext): Bound storage invariant validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ for full details on this and all prior releases.
   Azure deployment-stack behavior, production Terraform CI plan transport, and
   final release scorecard evidence remain explicit pre-cutover gates.
 
+### Fixed (APEX vNext security)
+
+- fix(vnext): replaced polynomial storage-security regular expressions over generated Bicep and Terraform source with
+  a bounded line-oriented assignment scan. Adversarial dual-track coverage protects the fix in
+  [#537](https://github.com/jonathan-vella/apex/issues/537).
+
 ### Changed (Model migration — Claude Sonnet 4.6 → Claude Sonnet 5)
 
 - chore(agents): migrated all 11 agents/subagents in the Sonnet cohort

--- a/packages/capabilities/src/iac-generation.ts
+++ b/packages/capabilities/src/iac-generation.ts
@@ -548,6 +548,105 @@ function validationPlans(tree: GeneratedVirtualTree, cwd: string): CommandPlan[]
   return [];
 }
 
+interface StorageSecurityInvariant {
+  readonly diagnostic: string;
+  readonly keys: readonly string[];
+  readonly values: ReadonlySet<string>;
+}
+
+const BOOLEAN_TRUE = new Set(["true"]);
+const BOOLEAN_FALSE = new Set(["false"]);
+const TLS_1_2 = new Set(["'TLS1_2'", '"TLS1_2"']);
+const BICEP_STORAGE_INVARIANTS: readonly StorageSecurityInvariant[] = [
+  {
+    diagnostic: "minimumTlsVersion[^\\n]*['\"]TLS1_2['\"]|minimumTlsVersion[\\s\\S]*['\"]TLS1_2['\"]",
+    keys: ["minimumTlsVersion"],
+    values: TLS_1_2,
+  },
+  {
+    diagnostic: "supportsHttpsTrafficOnly[^\\n]*true",
+    keys: ["supportsHttpsTrafficOnly"],
+    values: BOOLEAN_TRUE,
+  },
+  {
+    diagnostic: "allowBlobPublicAccess[^\\n]*false",
+    keys: ["allowBlobPublicAccess"],
+    values: BOOLEAN_FALSE,
+  },
+  {
+    diagnostic: "allowSharedKeyAccess[^\\n]*false",
+    keys: ["allowSharedKeyAccess"],
+    values: BOOLEAN_FALSE,
+  },
+];
+const TERRAFORM_STORAGE_INVARIANTS: readonly StorageSecurityInvariant[] = [
+  {
+    diagnostic:
+      "(?:minimumTlsVersion|min_tls_version)[^\\n]*['\"]TLS1_2['\"]|(?:minimumTlsVersion|min_tls_version)[\\s\\S]*['\"]TLS1_2['\"]",
+    keys: ["minimumTlsVersion", "min_tls_version"],
+    values: TLS_1_2,
+  },
+  {
+    diagnostic: "(?:supportsHttpsTrafficOnly|https_traffic_only_enabled)[^\\n]*true",
+    keys: ["supportsHttpsTrafficOnly", "https_traffic_only_enabled"],
+    values: BOOLEAN_TRUE,
+  },
+  {
+    diagnostic: "(?:allowBlobPublicAccess|allow_nested_items_to_be_public)[^\\n]*false",
+    keys: ["allowBlobPublicAccess", "allow_nested_items_to_be_public"],
+    values: BOOLEAN_FALSE,
+  },
+  {
+    diagnostic: "(?:allowSharedKeyAccess|shared_access_key_enabled)[^\\n]*false",
+    keys: ["allowSharedKeyAccess", "shared_access_key_enabled"],
+    values: BOOLEAN_FALSE,
+  },
+];
+
+function assignmentToken(line: string): readonly [key: string, value: string] | undefined {
+  const colon = line.indexOf(":");
+  const equals = line.indexOf("=");
+  const separator = colon < 0 ? equals : equals < 0 ? colon : Math.min(colon, equals);
+  if (separator < 0) return undefined;
+  const rawKey = line.slice(0, separator).trim();
+  const remainder = line.slice(separator + 1).trimStart();
+  if (rawKey.length === 0 || remainder.length === 0) return undefined;
+  const keyQuote = rawKey[0];
+  const key = (keyQuote === "'" || keyQuote === '"') && rawKey.at(-1) === keyQuote ? rawKey.slice(1, -1) : rawKey;
+  const quote = remainder[0];
+  if (quote === "'" || quote === '"') {
+    const end = remainder.indexOf(quote, 1);
+    return end < 0 ? undefined : [key, remainder.slice(0, end + 1)];
+  }
+  let end = 0;
+  while (end < remainder.length && !" \t\r,}]".includes(remainder[end]!)) end += 1;
+  return [key, remainder.slice(0, end)];
+}
+
+function missingStorageInvariants(
+  source: string,
+  invariants: readonly StorageSecurityInvariant[],
+): readonly StorageSecurityInvariant[] {
+  const invariantsByKey = new Map<string, StorageSecurityInvariant[]>();
+  for (const invariant of invariants) {
+    for (const key of invariant.keys) {
+      const entries = invariantsByKey.get(key) ?? [];
+      entries.push(invariant);
+      invariantsByKey.set(key, entries);
+    }
+  }
+  const found = new Set<StorageSecurityInvariant>();
+  for (const line of source.split("\n")) {
+    const assignment = assignmentToken(line);
+    if (assignment === undefined) continue;
+    const [key, value] = assignment;
+    for (const invariant of invariantsByKey.get(key) ?? []) {
+      if (invariant.values.has(value)) found.add(invariant);
+    }
+  }
+  return invariants.filter((invariant) => !found.has(invariant));
+}
+
 export async function validateGeneratedTree(
   tree: GeneratedVirtualTree,
   options: GeneratedTreeValidationOptions = {},
@@ -592,22 +691,9 @@ export async function validateGeneratedTree(
   );
   if (storageResources.length > 0) {
     const source = tree.files.map(({ content }) => content).join("\n");
-    const required =
-      tree.logicalManifest.track === "bicep"
-        ? [
-            /minimumTlsVersion[^\n]*['"]TLS1_2['"]|minimumTlsVersion[\s\S]*['"]TLS1_2['"]/,
-            /supportsHttpsTrafficOnly[^\n]*true/,
-            /allowBlobPublicAccess[^\n]*false/,
-            /allowSharedKeyAccess[^\n]*false/,
-          ]
-        : [
-            /(?:minimumTlsVersion|min_tls_version)[^\n]*['"]TLS1_2['"]|(?:minimumTlsVersion|min_tls_version)[\s\S]*['"]TLS1_2['"]/,
-            /(?:supportsHttpsTrafficOnly|https_traffic_only_enabled)[^\n]*true/,
-            /(?:allowBlobPublicAccess|allow_nested_items_to_be_public)[^\n]*false/,
-            /(?:allowSharedKeyAccess|shared_access_key_enabled)[^\n]*false/,
-          ];
-    for (const invariant of required)
-      if (!invariant.test(source)) issues.push(`Storage security invariant '${invariant.source}' is missing`);
+    const required = tree.logicalManifest.track === "bicep" ? BICEP_STORAGE_INVARIANTS : TERRAFORM_STORAGE_INVARIANTS;
+    for (const invariant of missingStorageInvariants(source, required))
+      issues.push(`Storage security invariant '${invariant.diagnostic}' is missing`);
   }
   const plans = validationPlans(tree, options.cwd ?? ".");
   const commandResults: ProcessResult[] = [];

--- a/packages/capabilities/src/test/iac-generation.test.ts
+++ b/packages/capabilities/src/test/iac-generation.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 import test from "node:test";
 import type { IacBindingV1, ImplementationIntentV1 } from "@apex/contracts";
 import {
@@ -105,6 +106,52 @@ test("native generators are byte deterministic and enforce secure storage defaul
   );
   assert.equal((await validateGeneratedTree(first)).valid, true);
   assert.equal((await validateGeneratedTree(terraform)).valid, true);
+});
+
+test("storage validation remains bounded for repeated near-miss properties", async () => {
+  const sourceIntent = intent();
+  const cases = [
+    {
+      generated: generateBicepTree(
+        sourceIntent,
+        binding("bicep", "native:Microsoft.Storage/storageAccounts@2023-05-01", "2023-05-01", nativeParameters),
+      ),
+      declaration: "resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {",
+      properties: ["minimumTlsVersion", "supportsHttpsTrafficOnly", "allowBlobPublicAccess", "allowSharedKeyAccess"],
+      separator: ":",
+    },
+    {
+      generated: generateTerraformTree(
+        sourceIntent,
+        binding("terraform", "native:Microsoft.Storage/storageAccounts@2023-05-01", "2023-05-01", nativeParameters),
+      ),
+      declaration: 'resource "azurerm_storage_account" "storage" {',
+      properties: [
+        "min_tls_version",
+        "https_traffic_only_enabled",
+        "allow_nested_items_to_be_public",
+        "shared_access_key_enabled",
+      ],
+      separator: "=",
+    },
+  ] as const;
+
+  for (const { generated, declaration, properties, separator } of cases) {
+    const repeatedAssignments = properties
+      .map((property) => `${`${property} ${separator} invalid `.repeat(2_000)}\n`)
+      .join("");
+    const content = `${declaration}\n${repeatedAssignments}}\n`;
+    const files = [{ path: generated.logicalManifest.resources[0]!.sourcePath, content }];
+    const adversarialTree: GeneratedVirtualTree = { ...generated, files, treeHash: sha256(files) };
+
+    const startedAt = performance.now();
+    const result = await validateGeneratedTree(adversarialTree);
+    const elapsedMs = performance.now() - startedAt;
+
+    assert.equal(result.valid, false);
+    assert.equal(result.issues.filter((issue) => issue.startsWith("Storage security invariant")).length, 4);
+    assert.ok(elapsedMs < 500, `${generated.logicalManifest.track} validation took ${elapsedMs.toFixed(1)}ms`);
+  }
 });
 
 test("AVM generators preserve exact pins, harden storage, and only include supplied lock data", () => {


### PR DESCRIPTION
## Description

Replaces CodeQL alert #34's polynomial storage-security regular expressions with a line-oriented assignment scanner over generated Bicep and Terraform source. The scanner traverses source once, retains only constant invariant state, supports quoted native Terraform keys, and preserves the existing invariant diagnostics and property aliases.

## Related Issue

Addresses #537

## Type of Change

- [x] Bug fix
- [x] Security fix

## Changes Made

- Parse generated assignment keys and first value tokens without regular-expression backtracking.
- Match Bicep camel-case and Terraform camel/snake-case storage security properties.
- Add adversarial dual-track coverage with repeated near-miss assignments.
- Record the fix in the unreleased changelog.

## Performance Characterization

- Before: the Bicep near-miss fixture took approximately 971 ms.
- After: both Bicep and Terraform adversarial cases complete in approximately 16 ms combined locally.
- Regression bound: each track must complete within 500 ms and report all missing invariants.

## Testing Performed

- [x] Complete `@apex/capabilities` suite: 40 passed
- [x] `npm run lint:vnext`
- [x] `npm run validate:vnext`
- [x] `npm run test:vnext` across all workspaces
- [x] Prettier on changed TypeScript
- [x] Scoped Markdown lint
- [x] Pre-commit and pre-push hooks

## Verification Boundary

GitHub CodeQL uses default setup and does not attach checks to integration-targeting PRs. After a separately approved merge of this draft into `feat/apex-vnext-rewrite`, PR #533 must run default CodeQL on the new integration head and show alert #34 absent before issue #537 can close. The CodeQL CLI is unavailable locally.

This draft does not authorize merge, publication, tags, deployment, or cutover.