### PR TITLE
docs(vnext): Fix sibling page links

### DIFF
--- a/site/src/content/docs/vnext/cli-reference.md
+++ b/site/src/content/docs/vnext/cli-reference.md
@@ -116,4 +116,4 @@ apex gate decide --gate 4 --decision approved --actor local-user --json
 apex deploy --preview "$PREVIEW_HASH" --json
 ```
 
-See [operations](./operations/) for native provider configuration and [security](./security/) before deployment.
+See [operations](../operations/) for native provider configuration and [security](../security/) before deployment.

--- a/site/src/content/docs/vnext/installation.md
+++ b/site/src/content/docs/vnext/installation.md
@@ -64,4 +64,4 @@ reported conflict or restore the recorded base before retrying.
 4. Confirm the workspace MCP server starts from `.vscode/mcp.json`.
 5. Ask `APEX` for status and verify that it reads kernel state rather than inferring progress from chat.
 
-Continue with the [workflow](./workflow/) or run the full [qualification checklist](./testing/).
+Continue with the [workflow](../workflow/) or run the full [qualification checklist](../testing/).

--- a/site/src/content/docs/vnext/operations.md
+++ b/site/src/content/docs/vnext/operations.md
@@ -101,4 +101,4 @@ combines run status with doctor results. Cache entries are deterministic and saf
 - Use `apex writer show` before transfer. Create and accept a claim only with the current repository head and intended
   recipient workflow; expired or stale claims must be recreated.
 
-Use the [CLI reference](./cli-reference/) for every flag and the [testing guide](./testing/) before a real sandbox run.
+Use the [CLI reference](../cli-reference/) for every flag and the [testing guide](../testing/) before a real sandbox run.

--- a/site/src/content/docs/vnext/security.md
+++ b/site/src/content/docs/vnext/security.md
@@ -54,4 +54,4 @@ or `.apex/local/`. Provider configuration must contain nonsecret settings only; 
 Resolve credentials only at operation time through Azure CLI, OIDC, Managed Identity, or another approved external
 credential source.
 
-Use the [operations guide](./operations/) to configure providers without secrets.
+Use the [operations guide](../operations/) to configure providers without secrets.

--- a/site/src/content/docs/vnext/workflow.md
+++ b/site/src/content/docs/vnext/workflow.md
@@ -50,4 +50,4 @@ risk scopes still match. The first mismatch reopens the affected gate.
 Environment-specific artifacts are never inherited. Every promoted run requires a fresh preview, Deployment Preview
 decision, deployment, inventory, and evidence for its own Azure scope.
 
-Use the [operations guide](./operations/) for commands and the [security model](./security/) for authority boundaries.
+Use the [operations guide](../operations/) for commands and the [security model](../security/) for authority boundaries.


### PR DESCRIPTION
## Description

Repairs the nine vNext cross-page links reported by docs run 29274684657. The affected pages are rendered as directories, so sibling pages require `../target/`; `./target/` incorrectly nested the target under the current page route.

## Related Issue

Addresses #539

## Changes Made

- Correct CLI reference links to Operations and Security.
- Correct Installation links to Workflow and Testing.
- Correct Operations links to CLI Reference and Testing.
- Correct Security link to Operations.
- Correct Workflow links to Operations and Security.
- Preserve the vNext index links, where `./child/` is correct.

## Testing Performed

- [x] Reproduced all nine failures from a scratch site build.
- [x] Rebuilt the site successfully.
- [x] Strict rendered-site check: all 9,413 internal links valid.
- [x] Staged-doc source link checks passed for all changed pages.
- [x] Scoped Markdown lint passed.
- [x] Documentation frontmatter validation passed.
- [x] Editor diagnostics, whitespace check, pre-commit hooks, and pre-push hooks passed.

## Verification Boundary

The `docs-checks` workflow is path-triggered for pull requests and should provide direct evidence on this draft. The devcontainer summary can only be re-evaluated on the updated integration head after a separately approved merge.

This draft does not authorize merge, publication, tags, deployment, or cutover.