### PR TITLE
docs(vnext): Scope governing prompt lint exceptions

### DIFF
--- a/.github/prompts/plan-governAndCompleteApexVnext.prompt.md
+++ b/.github/prompts/plan-governAndCompleteApexVnext.prompt.md
@@ -25,6 +25,8 @@ or self-modification loop.
 
 **Steps**
 
+<!-- markdownlint-disable MD013 MD029 -->
+
 ### Phase 1: Establish Project Controls
 
 1. Reconcile the project baseline before writing status. Record the current branch/head, dirty files, commits after
@@ -194,6 +196,8 @@ or self-modification loop.
     metric or unresolved critical/high risk blocks cutover.
 40. Only after explicit maintainer approval may the implementation prepare cutover artifacts, the v1 maintenance line,
     final tags/publication, and merge to `main`. These actions are deliberately excluded from autonomous execution.
+
+<!-- markdownlint-enable MD013 MD029 -->
 
 **Relevant files**
 


### PR DESCRIPTION
Closes #553

Adds scoped MD013/MD029 directives around the approved globally numbered Steps block. Removing the two directives reproduces the exact original prompt bytes. Full repository Markdown lint and prompt validation pass. No plan prose, numbering, ordering, or execution semantics changed.