### PR TITLE
feat: enforce workflow validator ownership

### DIFF
--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -12,4 +12,5 @@ export * from "./run-repository.js";
 export * from "./tasks.js";
 export * from "./validator-registry.js";
 export * from "./workflow-engine.js";
+export * from "./workflow-validator-ownership.js";
 export * from "./writer-transfer.js";

--- a/packages/kernel/src/test/workflow-engine.test.ts
+++ b/packages/kernel/src/test/workflow-engine.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { composeDependencyHash, WorkflowEngine } from "../index.js";
+import { composeDependencyHash, WorkflowEngine, workflowValidatorOwnership } from "../index.js";
 
 const manifest = JSON.parse(
   await readFile(new URL("../../../../config/workflow.v1.json", import.meta.url), "utf8"),
@@ -9,6 +9,14 @@ const manifest = JSON.parse(
 
 test("workflow manifest validates and routes both tracks deterministically", () => {
   const engine = new WorkflowEngine(manifest);
+  assert.deepEqual(engine.manifest.nodes[0]?.validators, [
+    "schema:requirements-v1",
+    "business:requirements-completeness",
+    "review:requirements-comprehensive",
+  ]);
+  assert.ok(
+    engine.manifest.nodes.flatMap(({ validators }) => validators).every((id) => workflowValidatorOwnership(id)),
+  );
   const initial = engine.route({ run: { iacTool: "bicep" }, artifacts: {} });
   assert.equal(initial.currentNode, "requirements");
   assert.equal(initial.ownerRole, "requirements");
@@ -75,6 +83,16 @@ test("workflow rejects unknown operators, cycles, duplicate gates, and missing t
       oneTrack.nodes.some((node: any) => node.id === edge.to),
   );
   assert.throws(() => new WorkflowEngine(oneTrack), /bicep and terraform/);
+});
+
+test("workflow rejects unowned and duplicate validator IDs", () => {
+  const unknown = structuredClone(manifest) as any;
+  unknown.nodes[0].validators[0] = "schema:unknown-v1";
+  assert.throws(() => new WorkflowEngine(unknown), /Unknown workflow validator schema:unknown-v1/);
+
+  const duplicate = structuredClone(manifest) as any;
+  duplicate.nodes[0].validators.push(duplicate.nodes[0].validators[0]);
+  assert.throws(() => new WorkflowEngine(duplicate), /Duplicate workflow validator/);
 });
 
 test("dependency hashes are canonical and invalidation cascades with semantic reasons", () => {

--- a/packages/kernel/src/workflow-engine.ts
+++ b/packages/kernel/src/workflow-engine.ts
@@ -1,4 +1,5 @@
 import { sha256Json, type JsonValue } from "./canonical.js";
+import { workflowValidatorOwnership } from "./workflow-validator-ownership.js";
 
 const OPERATORS = new Set(["all", "equals", "in", "exists", "not"]);
 
@@ -17,6 +18,7 @@ export interface WorkflowNode {
   condition?: WorkflowCondition;
   sourceDependencies: string[];
   outputs: string[];
+  validators: string[];
   invalidates: string[];
 }
 
@@ -188,6 +190,15 @@ export function validateWorkflowManifest(value: unknown): WorkflowManifest {
 function parseNode(value: unknown): WorkflowNode {
   if (!isRecord(value)) throw new Error("Workflow node must be an object");
   const condition = value.condition === undefined ? undefined : parseCondition(value.condition);
+  const validators = optionalStringArray(value.validators, "validators");
+  if (new Set(validators).size !== validators.length) {
+    throw new Error(`Duplicate workflow validator on node ${requiredString(value.id, "node id")}`);
+  }
+  for (const validator of validators) {
+    if (workflowValidatorOwnership(validator) === undefined) {
+      throw new Error(`Unknown workflow validator ${validator}`);
+    }
+  }
   return {
     id: requiredString(value.id, "node id"),
     kind: requiredString(value.kind, "node kind"),
@@ -196,6 +207,7 @@ function parseNode(value: unknown): WorkflowNode {
     ...(condition === undefined ? {} : { condition }),
     sourceDependencies: optionalStringArray(value.sourceDependencies, "sourceDependencies"),
     outputs: optionalStringArray(value.outputs, "outputs"),
+    validators,
     invalidates: optionalStringArray(value.invalidates, "invalidates"),
   };
 }

--- a/packages/kernel/src/workflow-validator-ownership.ts
+++ b/packages/kernel/src/workflow-validator-ownership.ts
@@ -1,0 +1,159 @@
+export type WorkflowValidatorExecution = "schema" | "inline" | "capability" | "review" | "external-command";
+
+export interface WorkflowValidatorOwnership {
+  readonly id: string;
+  readonly owner: "@apex/kernel" | "@apex/capabilities" | "@apex/cli";
+  readonly entrypoint: string;
+  readonly execution: WorkflowValidatorExecution;
+}
+
+interface OwnershipGroup extends Omit<WorkflowValidatorOwnership, "id"> {
+  readonly ids: readonly string[];
+}
+
+const ownershipGroups: readonly OwnershipGroup[] = [
+  {
+    ids: [
+      "schema:architecture-v1",
+      "schema:governance-constraints-v1",
+      "schema:iac-binding-v1",
+      "schema:implementation-intent-v1",
+      "schema:policy-property-map-v1",
+      "schema:requirements-v1",
+    ],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.assertValid",
+    execution: "schema",
+  },
+  {
+    ids: [
+      "business:availability-current",
+      "business:bicep-binding-coverage",
+      "business:binding-track-match",
+      "business:cost-arithmetic",
+      "business:dependency-acyclic",
+      "business:governance-completeness",
+      "business:governance-freshness",
+      "business:plan-source-coverage",
+      "business:policy-effect-coverage",
+      "business:policy-property-map",
+      "business:requirements-completeness",
+      "business:requirements-traceability",
+      "business:terraform-binding-coverage",
+    ],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.completeTask",
+    execution: "inline",
+  },
+  {
+    ids: ["business:logical-resource-parity", "business:security-baseline"],
+    owner: "@apex/capabilities",
+    entrypoint: "validateGeneratedTree",
+    execution: "capability",
+  },
+  {
+    ids: [
+      "review:architecture-comprehensive",
+      "review:governance-reconciliation",
+      "review:plan-comprehensive",
+      "review:requirements-comprehensive",
+    ],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.reviewBlockers",
+    execution: "review",
+  },
+  {
+    ids: ["gate:architecture-cost-governance-ready", "gate:implementation-plan-ready", "gate:requirements-ready"],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.route",
+    execution: "inline",
+  },
+  {
+    ids: ["gate:approval-binding-complete", "gate:no-hard-blockers", "gate:preview-current"],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.assertPreviewReady",
+    execution: "inline",
+  },
+  {
+    ids: ["bicep:build", "bicep:format", "bicep:lint"],
+    owner: "@apex/capabilities",
+    entrypoint: "validateGeneratedTree",
+    execution: "external-command",
+  },
+  {
+    ids: ["terraform:format", "terraform:init-backend-false", "terraform:validate"],
+    owner: "@apex/capabilities",
+    entrypoint: "validateGeneratedTree",
+    execution: "external-command",
+  },
+  {
+    ids: ["terraform:saved-plan-binding"],
+    owner: "@apex/capabilities",
+    entrypoint: "NativeTerraformProvider.previewApply",
+    execution: "capability",
+  },
+  {
+    ids: ["preview:coverage", "preview:freshness", "preview:hash-bindings", "preview:policy-precheck"],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.assertPreviewReady",
+    execution: "inline",
+  },
+  {
+    ids: ["deploy:exact-approved-operation", "deploy:stale-writer-rejection"],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.deploy",
+    execution: "inline",
+  },
+  {
+    ids: ["deploy:bicep-stack-ownership"],
+    owner: "@apex/capabilities",
+    entrypoint: "NativeBicepProvider.apply",
+    execution: "capability",
+  },
+  {
+    ids: ["deploy:exact-saved-plan", "deploy:state-lineage-and-serial"],
+    owner: "@apex/capabilities",
+    entrypoint: "NativeTerraformProvider.apply",
+    execution: "capability",
+  },
+  {
+    ids: ["inventory:eventual-consistency-reconciled", "inventory:secret-free", "inventory:source-coverage"],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.inventory",
+    execution: "inline",
+  },
+  {
+    ids: ["diagnosis:read-only", "diagnosis:secret-free"],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.diagnose",
+    execution: "inline",
+  },
+  {
+    ids: ["quality:no-subjective-deterministic-claims", "quality:scorecard-decidable"],
+    owner: "@apex/cli",
+    entrypoint: "evaluateQuality",
+    execution: "inline",
+  },
+  {
+    ids: ["terminal:run-evidence-complete"],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.status",
+    execution: "inline",
+  },
+];
+
+const ownershipEntries = ownershipGroups.flatMap(({ ids, ...ownership }) =>
+  ids.map((id): WorkflowValidatorOwnership => ({ id, ...ownership })),
+);
+
+export const WORKFLOW_VALIDATOR_OWNERSHIP: ReadonlyMap<string, WorkflowValidatorOwnership> = new Map(
+  ownershipEntries.map((entry) => [entry.id, entry]),
+);
+
+if (WORKFLOW_VALIDATOR_OWNERSHIP.size !== ownershipEntries.length) {
+  throw new Error("Workflow validator ownership contains duplicate IDs");
+}
+
+export function workflowValidatorOwnership(id: string): WorkflowValidatorOwnership | undefined {
+  return WORKFLOW_VALIDATOR_OWNERSHIP.get(id);
+}


### PR DESCRIPTION
## Summary
- preserve ordered `validators[]` on typed workflow nodes
- reject unknown and duplicate validator IDs during manifest construction
- add a code-owned catalog for all current workflow validator IDs
- characterize ownership coverage without claiming semantic dispatch

## Validation
- `npm run build --workspace @apex/kernel`
- `npm test --workspace @apex/kernel`
- `npm run lint:vnext`
- targeted Prettier and cache-free ESLint
- `npm run validate:vnext`
- `npm run test:vnext` (sequentially after asset preparation)

Tracks #559
Parent #542