### PR TITLE
feat: dispatch workflow task validators

### DIFF
--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -71,6 +71,7 @@ import {
   openGate,
   sha256Bytes,
   sha256Json,
+  workflowValidatorOwnership,
   type JsonValue,
 } from "@apex/kernel";
 import {
@@ -85,6 +86,11 @@ import { access, cp, lstat, mkdir, readFile, readdir, realpath, rename, rm, stat
 import { basename, delimiter, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { resolveBundledAssets } from "./assets.js";
 import { ApexError, EXIT_CODES } from "./errors.js";
+import {
+  registerTaskWorkflowValidators,
+  taskWorkflowValidatorInput,
+  type WorkflowTaskValidatorContext,
+} from "./workflow-validators.js";
 
 const ZERO_HASH = "0".repeat(64);
 const TASK_TTL_MS = 24 * 60 * 60 * 1000;
@@ -283,6 +289,7 @@ export class ApexService {
     for (const [, [validator, schema]] of Object.entries(ARTIFACTS)) this.validators.register(validator, schema);
     this.validators.register("approval", ApprovalEvidenceV1Schema);
     this.validators.register("runtime-lock", RuntimeBundleLockV1Schema);
+    registerTaskWorkflowValidators(this.validators);
     this.providers = {
       fake: new FakeIaCProvider({ track: "bicep", now: this.clock, nextId: this.idSource }),
       ...options.providers,
@@ -830,6 +837,7 @@ export class ApexService {
       this.validateOutput(run, output);
     }
     await this.validateBundle(run, descriptor, outputs);
+    const validatorIds = await this.validateTaskValidators(descriptor, outputs);
     const outputHashes: Partial<Record<ArtifactKind, string>> = {};
     for (const output of outputs) outputHashes[output.kind] = await this.objects.putJson(output.value);
     const reviewBlockers = descriptor.reviewSubject === undefined ? [] : this.openReviewFindings(outputs[0]!.value);
@@ -838,6 +846,7 @@ export class ApexService {
       taskId,
       nodeId: descriptor.id,
       artifactHashes: outputHashes,
+      validatorIds,
       reviewBlockers,
       ...(descriptor.reviewSubject === undefined
         ? {}
@@ -2056,6 +2065,47 @@ export class ApexService {
         );
       }
     }
+  }
+
+  private async validateTaskValidators(descriptor: WorkflowTaskDescriptor, outputs: TaskOutput[]): Promise<string[]> {
+    const workflow = new WorkflowEngine(
+      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
+    );
+    const nodeId = descriptor.reviewSubject ?? descriptor.id;
+    const node = workflow.manifest.nodes.find(({ id }) => id === nodeId);
+    if (node === undefined) throw new Error(`Workflow task ${nodeId} has no manifest node`);
+    const boundary =
+      descriptor.reviewSubject !== undefined
+        ? "review"
+        : descriptor.id.startsWith("validation-")
+          ? "validation"
+          : "task-output";
+    const validatorIds = node.validators.filter((id) => workflowValidatorOwnership(id)?.boundary === boundary);
+    const run = await this.currentRun();
+    const events = await this.journal(run).replay();
+    const artifactHashes: Record<string, string> = {};
+    for (const event of events) {
+      if (event.type !== "task.completed") continue;
+      const hashes = (event.payload as { artifactHashes?: Record<string, unknown> }).artifactHashes ?? {};
+      for (const [kind, hash] of Object.entries(hashes)) if (typeof hash === "string") artifactHashes[kind] = hash;
+    }
+    const artifacts = Object.fromEntries(
+      await Promise.all(
+        Object.entries(artifactHashes).map(async ([kind, hash]) => [kind, await this.objects.getJson<unknown>(hash)]),
+      ),
+    );
+    const context: WorkflowTaskValidatorContext = {
+      nodeId,
+      now: this.clock().toISOString(),
+      track: run.iacTool,
+      outputs: Object.fromEntries(outputs.map(({ kind, value }) => [kind, value])),
+      artifacts,
+      artifactHashes,
+    };
+    for (const id of validatorIds) {
+      this.assertValid(id, taskWorkflowValidatorInput(id, context));
+    }
+    return validatorIds;
   }
 
   private initialSkuManifest(run: RunConfigV1, requirements: unknown): unknown {

--- a/packages/cli/src/test/expanded-workflow.test.ts
+++ b/packages/cli/src/test/expanded-workflow.test.ts
@@ -3,7 +3,8 @@ import { join } from "node:path";
 import test from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { sha256Json } from "@apex/kernel";
+import type { IacBindingV1, ImplementationIntentV1, LogicalResourceManifestV1 } from "@apex/contracts";
+import { EventJournal, sha256Json } from "@apex/kernel";
 import { ApexError } from "../errors.js";
 import { createMcpServer } from "../mcp.js";
 import { ApexService, type TaskOutput } from "../service.js";
@@ -74,7 +75,17 @@ async function reachCodegen(
   ]);
   await service.decideGateNumber(2, "approved", "tester");
 
-  const plan = planBundle(runId, track);
+  const plan = planBundle(
+    runId,
+    track,
+    {},
+    {
+      requirements: requirementHashes.requirements!,
+      architecture: architectureHashes.architecture!,
+      "governance-constraints": governanceHashes["governance-constraints"]!,
+      "policy-property-map": policyHashes["policy-property-map"]!,
+    },
+  );
   const planHashes = await complete(service, "plan", plan);
   await complete(service, "plan-review", [
     { kind: "review-findings", value: review(runId, "plan", planHashes["implementation-intent"]!) },
@@ -86,8 +97,208 @@ async function reachCodegen(
 async function reachValidation(service: ApexService, runId: string, track: "bicep" | "terraform"): Promise<void> {
   const codegen = await reachCodegen(service, runId, track);
   await service.completeTaskOutputs(codegen.taskId, codegenBundle(runId, track, codegen.plan));
-  await complete(service, `validation-${track}`, [{ kind: "validation-evidence", value: validationEvidence(runId) }]);
+  await complete(service, `validation-${track}`, [
+    { kind: "validation-evidence", value: validationEvidence(runId, track) },
+  ]);
 }
+
+test("task completion records executed manifest validators in order", async () => {
+  const root = await tempRoot();
+  const service = new ApexService(root);
+  const { runId } = await service.init({ projectId: "demo" });
+  await service.nextTask();
+  await complete(service, "requirements", [
+    { kind: "requirements", value: requirements() },
+    { kind: "sku-manifest", value: skuManifest(sha256Json(requirements())) },
+  ]);
+
+  const events = await new EventJournal(join(root, ".apex", "projects", "demo", "runs", runId, "journal")).replay();
+  const completed = events.find(
+    (event) => event.type === "task.completed" && (event.payload as { nodeId?: unknown }).nodeId === "requirements",
+  );
+  assert.deepEqual((completed?.payload as { validatorIds?: unknown }).validatorIds, [
+    "schema:requirements-v1",
+    "business:requirements-completeness",
+  ]);
+});
+
+test("task-bound workflow validators reject semantic and evidence mutations", async () => {
+  const root = await tempRoot();
+  const service = new ApexService(root);
+  const { runId } = await service.init({ projectId: "demo", iacTool: "bicep" });
+  await service.nextTask();
+
+  const requirementTask = await task(service, "requirements");
+  const duplicateRequirements = structuredClone(requirements());
+  duplicateRequirements.requirements.push({ ...duplicateRequirements.requirements[0]! });
+  await assert.rejects(
+    service.completeTaskOutputs(requirementTask, [
+      { kind: "requirements", value: duplicateRequirements },
+      { kind: "sku-manifest", value: skuManifest(sha256Json(duplicateRequirements)) },
+    ]),
+    /business:requirements-completeness/,
+  );
+  const requirementValues = requirements();
+  const requirementHashes = await service.completeTaskOutputs(requirementTask, [
+    { kind: "requirements", value: requirementValues },
+    { kind: "sku-manifest", value: skuManifest(sha256Json(requirementValues)) },
+  ]);
+
+  const requirementReviewTask = await task(service, "requirements-review");
+  const duplicateFinding = {
+    id: "F-1",
+    severity: "info",
+    disposition: "dismissed",
+    title: "Duplicate",
+    detail: "Duplicate review identifier",
+    evidenceRefs: [],
+  };
+  await assert.rejects(
+    service.completeTaskOutputs(requirementReviewTask, [
+      {
+        kind: "review-findings",
+        value: review(runId, "requirements", requirementHashes.outputHashes.requirements!, [
+          duplicateFinding,
+          duplicateFinding,
+        ]),
+      },
+    ]),
+    /review:requirements-comprehensive/,
+  );
+  await service.completeTaskOutputs(requirementReviewTask, [
+    {
+      kind: "review-findings",
+      value: review(runId, "requirements", requirementHashes.outputHashes.requirements!),
+    },
+  ]);
+  await service.decideGateNumber(1, "approved", "tester");
+
+  const architectureTask = await task(service, "architecture");
+  const untraceableArchitecture = architecture(runId);
+  untraceableArchitecture.components[0]!.requirementIds = ["REQ-UNKNOWN"];
+  await assert.rejects(
+    service.completeTaskOutputs(architectureTask, [
+      { kind: "architecture", value: untraceableArchitecture },
+      { kind: "cost-estimate", value: costEstimate(runId) },
+    ]),
+    /business:requirements-traceability/,
+  );
+  const architectureHashes = await service.completeTaskOutputs(architectureTask, [
+    { kind: "architecture", value: architecture(runId) },
+    { kind: "cost-estimate", value: costEstimate(runId) },
+  ]);
+  const architectureEvents = await new EventJournal(
+    join(root, ".apex", "projects", "demo", "runs", runId, "journal"),
+  ).replay();
+  const architectureCompleted = architectureEvents.find(
+    (event) => event.type === "task.completed" && (event.payload as { nodeId?: unknown }).nodeId === "architecture",
+  );
+  assert.deepEqual((architectureCompleted?.payload as { validatorIds?: unknown }).validatorIds, [
+    "schema:architecture-v1",
+    "business:requirements-traceability",
+    "business:cost-arithmetic",
+  ]);
+  await complete(service, "architecture-review", [
+    {
+      kind: "review-findings",
+      value: review(runId, "architecture", architectureHashes.outputHashes.architecture!),
+    },
+  ]);
+
+  const governanceTask = await task(service, "governance-discovery");
+  await assert.rejects(
+    service.completeTaskOutputs(governanceTask, [
+      { kind: "governance-constraints", value: { ...governance(runId), expiresAt: "2020-01-01T00:00:00.000Z" } },
+    ]),
+    /business:governance-freshness/,
+  );
+  const multiEffectGovernance = governance(runId);
+  multiEffectGovernance.summary.assignmentCount = 1;
+  multiEffectGovernance.summary.denyCount = 1;
+  multiEffectGovernance.summary.auditCount = 1;
+  multiEffectGovernance.constraintsRef.bytes = 1;
+  const governanceHashes = await service.completeTaskOutputs(governanceTask, [
+    { kind: "governance-constraints", value: multiEffectGovernance },
+  ]);
+  const policyHashes = await complete(service, "governance-reconciliation", [
+    {
+      kind: "policy-property-map",
+      value: {
+        ...policyMap(runId, governanceHashes.outputHashes["governance-constraints"]!),
+        mappings: [
+          {
+            policyAssignmentId: "assignment-1",
+            effect: "deny",
+            logicalResourceId: "api",
+            propertyPath: "properties.deny",
+            disposition: "planned",
+          },
+          {
+            policyAssignmentId: "assignment-1",
+            effect: "audit",
+            logicalResourceId: "api",
+            propertyPath: "properties.audit",
+            disposition: "planned",
+          },
+        ],
+      },
+    },
+  ]);
+  await complete(service, "governance-review", [
+    {
+      kind: "review-findings",
+      value: review(runId, "policy-property-map", policyHashes["policy-property-map"]!),
+    },
+  ]);
+  await service.decideGateNumber(2, "approved", "tester");
+
+  const sourceHashes = {
+    requirements: requirementHashes.outputHashes.requirements!,
+    architecture: architectureHashes.outputHashes.architecture!,
+    "governance-constraints": governanceHashes.outputHashes["governance-constraints"]!,
+    "policy-property-map": policyHashes["policy-property-map"]!,
+  };
+  const validPlan = planBundle(runId, "bicep", {}, sourceHashes);
+  const cyclicPlan = structuredClone(validPlan) as TaskOutput[];
+  const cyclicIntent = cyclicPlan[0]!.value as ImplementationIntentV1;
+  cyclicIntent.resources[0]!.dependsOn = ["worker"];
+  cyclicIntent.resources.push({ ...cyclicIntent.resources[0]!, id: "worker", dependsOn: ["api"] });
+  const cyclicBinding = cyclicPlan[1]!.value as IacBindingV1;
+  cyclicBinding.resourceBindings.worker = { ...cyclicBinding.resourceBindings.api! };
+  cyclicBinding.intentHash = sha256Json(cyclicIntent);
+  const planTask = await task(service, "plan");
+  await assert.rejects(service.completeTaskOutputs(planTask, cyclicPlan), /business:dependency-acyclic/);
+  const planHashes = await service.completeTaskOutputs(planTask, validPlan);
+  await complete(service, "plan-review", [
+    {
+      kind: "review-findings",
+      value: review(runId, "plan", planHashes.outputHashes["implementation-intent"]!),
+    },
+  ]);
+  await service.decideGateNumber(3, "approved", "tester");
+
+  const validCodegen = codegenBundle(runId, "bicep", validPlan);
+  const incompleteCodegen = structuredClone(validCodegen) as TaskOutput[];
+  const incompleteManifest = incompleteCodegen[0]!.value as LogicalResourceManifestV1;
+  incompleteManifest.resources[0]!.logicalId = "other";
+  (incompleteCodegen[1]!.value as { logicalResourceManifestHash: string }).logicalResourceManifestHash =
+    sha256Json(incompleteManifest);
+  const codegenTask = await task(service, "codegen-bicep");
+  await assert.rejects(service.completeTaskOutputs(codegenTask, incompleteCodegen), /business:bicep-binding-coverage/);
+  await service.completeTaskOutputs(codegenTask, validCodegen);
+
+  const validEvidence = validationEvidence(runId, "bicep");
+  const incompleteEvidence = {
+    ...validEvidence,
+    entries: validEvidence.entries.filter(({ kind }) => kind !== "bicep:format"),
+  };
+  const validationTask = await task(service, "validation-bicep");
+  await assert.rejects(
+    service.completeTaskOutputs(validationTask, [{ kind: "validation-evidence", value: incompleteEvidence }]),
+    /bicep:format/,
+  );
+  await service.completeTaskOutputs(validationTask, [{ kind: "validation-evidence", value: validEvidence }]);
+});
 
 for (const track of ["bicep", "terraform"] as const) {
   test(`full logical ${track} workflow reaches fake deploy and quality`, async () => {
@@ -270,14 +481,21 @@ test("plan rejects wrong track and secret literals", async () => {
   const isolated = new ApexService(await tempRoot());
   const initialized = await isolated.init({ projectId: "demo", iacTool: "bicep" });
   await isolated.nextTask();
-  await isolated.completeTask(await task(isolated, "requirements"), { kind: "requirements", value: requirements() });
+  const acceptedRequirements = await isolated.completeTask(await task(isolated, "requirements"), {
+    kind: "requirements",
+    value: requirements(),
+  });
   await isolated.decideGateNumber(1, "approved", "tester");
   const planTask = await task(isolated, "plan");
-  await assert.rejects(isolated.completeTaskOutputs(planTask, planBundle(initialized.runId, "terraform")), /track/i);
+  const sourceHashes = { requirements: acceptedRequirements.outputHash };
+  await assert.rejects(
+    isolated.completeTaskOutputs(planTask, planBundle(initialized.runId, "terraform", {}, sourceHashes)),
+    /track/i,
+  );
   await assert.rejects(
     isolated.completeTaskOutputs(
       planTask,
-      planBundle(initialized.runId, "bicep", { password: { kind: "value", value: "literal" } }),
+      planBundle(initialized.runId, "bicep", { password: { kind: "value", value: "literal" } }, sourceHashes),
     ),
     /secret-reference/i,
   );

--- a/packages/cli/src/test/helpers.ts
+++ b/packages/cli/src/test/helpers.ts
@@ -35,12 +35,16 @@ export function requirements(projectId = "demo"): RequirementsV1 {
   };
 }
 
-export function intent(runId: string, projectId = "demo"): ImplementationIntentV1 {
+export function intent(
+  runId: string,
+  projectId = "demo",
+  sourceHashes: Record<string, string> = { requirements: "a".repeat(64) },
+): ImplementationIntentV1 {
   return {
     schemaVersion: CONTRACT_VERSION,
     projectId,
     runId,
-    sourceHashes: { requirements: "a".repeat(64) },
+    sourceHashes,
     resources: [{ id: "api", type: "fake/service", purpose: "Serve requests", dependsOn: [], controls: [] }],
     outputs: ["endpoint"],
   };
@@ -114,7 +118,7 @@ export function governance(runId: string) {
     runId,
     targetScope: "local",
     discoveredAt: "2026-01-01T00:00:00.000Z",
-    expiresAt: "2027-01-01T00:00:00.000Z",
+    expiresAt: "2099-01-01T00:00:00.000Z",
     summary: { assignmentCount: 0, denyCount: 0, modifyCount: 0, auditCount: 0, exemptionCount: 0 },
     constraintsRef: { mediaType: "application/json", uri: "memory://constraints", digest: "b".repeat(64), bytes: 0 },
   };
@@ -128,8 +132,9 @@ export function planBundle(
   runId: string,
   track: "bicep" | "terraform",
   environmentInputs: Record<string, unknown> = {},
+  sourceHashes: Record<string, string> = { requirements: "a".repeat(64) },
 ) {
-  const implementation = intent(runId);
+  const implementation = intent(runId, "demo", sourceHashes);
   return [
     { kind: "implementation-intent" as const, value: implementation },
     {
@@ -203,13 +208,24 @@ export function codegenBundle(runId: string, track: "bicep" | "terraform", plan:
   ];
 }
 
-export function validationEvidence(runId: string) {
+export function validationEvidence(runId: string, track: "bicep" | "terraform") {
+  const validatorIds =
+    track === "bicep"
+      ? ["bicep:format", "bicep:build", "bicep:lint"]
+      : ["terraform:format", "terraform:init-backend-false", "terraform:validate"];
+  validatorIds.push("business:security-baseline", "business:policy-property-map", "business:logical-resource-parity");
   return {
     schemaVersion: CONTRACT_VERSION,
     projectId: "demo",
     runId,
     createdAt: "2026-01-01T00:00:00.000Z",
-    entries: [{ kind: "test", hash: "d".repeat(64), bytes: 1, required: true, retention: "immutable" }],
+    entries: validatorIds.map((kind) => ({
+      kind,
+      hash: "d".repeat(64),
+      bytes: 1,
+      required: true,
+      retention: "immutable",
+    })),
   };
 }
 
@@ -253,12 +269,22 @@ export async function prepareValidatedRun(service: ApexService, runId: string, t
     },
   ]);
   await service.decideGateNumber(2, "approved", "tester");
-  const plan = planBundle(runId, track);
+  const plan = planBundle(
+    runId,
+    track,
+    {},
+    {
+      requirements: requirementHashes.outputHashes.requirements!,
+      architecture: architectureHashes.outputHashes.architecture!,
+      "governance-constraints": governanceHashes.outputHashes["governance-constraints"]!,
+      "policy-property-map": policyHashes.outputHashes["policy-property-map"]!,
+    },
+  );
   const planHashes = await complete("plan", plan);
   await complete("plan-review", [
     { kind: "review-findings", value: review(runId, "plan", planHashes.outputHashes["implementation-intent"]!) },
   ]);
   await service.decideGateNumber(3, "approved", "tester");
   await complete(`codegen-${track}`, codegenBundle(runId, track, plan));
-  await complete(`validation-${track}`, [{ kind: "validation-evidence", value: validationEvidence(runId) }]);
+  await complete(`validation-${track}`, [{ kind: "validation-evidence", value: validationEvidence(runId, track) }]);
 }

--- a/packages/cli/src/workflow-validators.ts
+++ b/packages/cli/src/workflow-validators.ts
@@ -1,0 +1,280 @@
+import {
+  ArchitectureV1Schema,
+  GovernanceConstraintsV1Schema,
+  IacBindingV1Schema,
+  ImplementationIntentV1Schema,
+  PolicyPropertyMapV1Schema,
+  RequirementsV1Schema,
+  hasValidCostArithmetic,
+  type ArchitectureV1,
+  type CostEstimateV1,
+  type EvidenceManifestV1,
+  type GovernanceConstraintsV1,
+  type IacBindingV1,
+  type ImplementationIntentV1,
+  type LogicalResourceManifestV1,
+  type PolicyPropertyMapV1,
+  type RequirementsV1,
+  type ReviewFindingsV1,
+} from "@apex/contracts";
+import { WORKFLOW_VALIDATOR_OWNERSHIP, sha256Json, type ValidationIssue, type ValidatorRegistry } from "@apex/kernel";
+
+export interface WorkflowTaskValidatorContext {
+  readonly nodeId: string;
+  readonly now: string;
+  readonly track: "bicep" | "terraform";
+  readonly outputs: Readonly<Record<string, unknown>>;
+  readonly artifacts: Readonly<Record<string, unknown>>;
+  readonly artifactHashes: Readonly<Record<string, string>>;
+}
+
+const VALIDATION_EVIDENCE_IDS = new Set([
+  "bicep:build",
+  "bicep:format",
+  "bicep:lint",
+  "business:logical-resource-parity",
+  "business:policy-property-map",
+  "business:security-baseline",
+  "terraform:format",
+  "terraform:init-backend-false",
+  "terraform:validate",
+]);
+
+function issue(path: string, message: string): ValidationIssue[] {
+  return [{ path, message }];
+}
+
+function taskContext(value: unknown): WorkflowTaskValidatorContext {
+  return value as WorkflowTaskValidatorContext;
+}
+
+function requirementsCompleteness(value: unknown): ValidationIssue[] {
+  const requirements = taskContext(value).outputs.requirements as RequirementsV1;
+  const ids = requirements.requirements.map(({ id }) => id);
+  return new Set(ids).size === ids.length ? [] : issue("/requirements", "Requirement IDs must be unique");
+}
+
+function requirementsTraceability(value: unknown): ValidationIssue[] {
+  const context = taskContext(value);
+  const architecture = context.outputs.architecture as ArchitectureV1;
+  const requirements = context.artifacts.requirements as RequirementsV1 | undefined;
+  if (requirements === undefined) return issue("/artifacts/requirements", "Accepted requirements are required");
+  const knownIds = new Set(requirements.requirements.map(({ id }) => id));
+  const referencedIds = architecture.components.flatMap(({ requirementIds }) => requirementIds);
+  const unknown = [...new Set(referencedIds.filter((id) => !knownIds.has(id)))].sort();
+  if (unknown.length > 0) {
+    return issue("/outputs/architecture/components", `Unknown requirement IDs: ${unknown.join(", ")}`);
+  }
+  const referenced = new Set(referencedIds);
+  const missing = requirements.requirements
+    .filter(({ priority, status, id }) => priority === "must" && status === "confirmed" && !referenced.has(id))
+    .map(({ id }) => id)
+    .sort();
+  return missing.length === 0
+    ? []
+    : issue("/outputs/architecture/components", `Uncovered confirmed must requirements: ${missing.join(", ")}`);
+}
+
+function costArithmetic(value: unknown): ValidationIssue[] {
+  const estimate = taskContext(value).outputs["cost-estimate"] as CostEstimateV1;
+  return hasValidCostArithmetic(estimate) ? [] : issue("/outputs/cost-estimate", "Cost arithmetic does not reconcile");
+}
+
+function governanceCompleteness(value: unknown): ValidationIssue[] {
+  const governance = taskContext(value).outputs["governance-constraints"] as GovernanceConstraintsV1;
+  const discoveredItems = Object.values(governance.summary).reduce((total, count) => total + count, 0);
+  return discoveredItems > 0 && governance.constraintsRef.bytes === 0
+    ? issue("/outputs/governance-constraints/constraintsRef/bytes", "Non-empty discovery requires evidence bytes")
+    : [];
+}
+
+function governanceFreshness(value: unknown): ValidationIssue[] {
+  const context = taskContext(value);
+  const governance = context.outputs["governance-constraints"] as GovernanceConstraintsV1;
+  const now = Date.parse(context.now);
+  if (Date.parse(governance.discoveredAt) > now) {
+    return issue("/outputs/governance-constraints/discoveredAt", "Governance discovery is from the future");
+  }
+  return Date.parse(governance.expiresAt) <= now
+    ? issue("/outputs/governance-constraints/expiresAt", "Governance discovery is stale")
+    : [];
+}
+
+function policyEffectCoverage(value: unknown): ValidationIssue[] {
+  const context = taskContext(value);
+  const governance = context.artifacts["governance-constraints"] as GovernanceConstraintsV1 | undefined;
+  const policyMap = context.outputs["policy-property-map"] as PolicyPropertyMapV1;
+  if (governance === undefined) {
+    return issue("/artifacts/governance-constraints", "Accepted governance constraints are required");
+  }
+  const counts = new Map<string, number>();
+  for (const mapping of policyMap.mappings) counts.set(mapping.effect, (counts.get(mapping.effect) ?? 0) + 1);
+  const missing = [
+    ["deny", governance.summary.denyCount],
+    ["modify", governance.summary.modifyCount],
+    ["audit", governance.summary.auditCount],
+  ].flatMap(([effect, required]) =>
+    (counts.get(effect as string) ?? 0) < (required as number) ? [effect as string] : [],
+  );
+  return missing.length === 0
+    ? []
+    : issue("/outputs/policy-property-map/mappings", `Missing policy effect coverage: ${missing.join(", ")}`);
+}
+
+function planSourceCoverage(value: unknown): ValidationIssue[] {
+  const context = taskContext(value);
+  const intent = context.outputs["implementation-intent"] as ImplementationIntentV1;
+  const requiredSources = ["requirements", "architecture", "governance-constraints", "policy-property-map"].filter(
+    (kind) => context.artifactHashes[kind] !== undefined,
+  );
+  const invalid = requiredSources.filter((kind) => intent.sourceHashes[kind] !== context.artifactHashes[kind]);
+  return invalid.length === 0
+    ? []
+    : issue("/outputs/implementation-intent/sourceHashes", `Missing or stale source hashes: ${invalid.join(", ")}`);
+}
+
+function bindingTrackMatch(value: unknown): ValidationIssue[] {
+  const context = taskContext(value);
+  const intent = context.outputs["implementation-intent"] as ImplementationIntentV1;
+  const binding = context.outputs["iac-binding"] as IacBindingV1;
+  const resourceIds = new Set(intent.resources.map(({ id }) => id));
+  const bindingIds = Object.keys(binding.resourceBindings);
+  return binding.track === context.track &&
+    binding.intentHash === sha256Json(intent) &&
+    bindingIds.length === resourceIds.size &&
+    bindingIds.every((id) => resourceIds.has(id))
+    ? []
+    : issue("/outputs/iac-binding", "IaC binding track, intent, or resource coverage is invalid");
+}
+
+function dependencyAcyclic(value: unknown): ValidationIssue[] {
+  const intent = taskContext(value).outputs["implementation-intent"] as ImplementationIntentV1;
+  const ids = intent.resources.map(({ id }) => id);
+  const known = new Set(ids);
+  if (known.size !== ids.length)
+    return issue("/outputs/implementation-intent/resources", "Resource IDs must be unique");
+  const unknown = intent.resources.flatMap(({ dependsOn }) => dependsOn.filter((id) => !known.has(id)));
+  if (unknown.length > 0) {
+    return issue(
+      "/outputs/implementation-intent/resources",
+      `Unknown resource dependencies: ${[...new Set(unknown)].sort().join(", ")}`,
+    );
+  }
+  const incoming = new Map(ids.map((id) => [id, 0]));
+  const outgoing = new Map(ids.map((id) => [id, [] as string[]]));
+  for (const resource of intent.resources) {
+    for (const dependency of resource.dependsOn) {
+      incoming.set(resource.id, (incoming.get(resource.id) ?? 0) + 1);
+      outgoing.get(dependency)?.push(resource.id);
+    }
+  }
+  const pending = ids.filter((id) => incoming.get(id) === 0);
+  let visited = 0;
+  while (pending.length > 0) {
+    const id = pending.shift();
+    if (id === undefined) break;
+    visited += 1;
+    for (const dependent of outgoing.get(id) ?? []) {
+      const count = (incoming.get(dependent) ?? 0) - 1;
+      incoming.set(dependent, count);
+      if (count === 0) pending.push(dependent);
+    }
+  }
+  return visited === ids.length ? [] : issue("/outputs/implementation-intent/resources", "Resource graph has a cycle");
+}
+
+function bindingCoverage(expectedTrack: "bicep" | "terraform", value: unknown): ValidationIssue[] {
+  const context = taskContext(value);
+  const intent = context.artifacts["implementation-intent"] as ImplementationIntentV1 | undefined;
+  const binding = context.artifacts["iac-binding"] as IacBindingV1 | undefined;
+  const manifest = context.outputs["logical-resource-manifest"] as LogicalResourceManifestV1;
+  if (intent === undefined || binding === undefined) {
+    return issue("/artifacts", "Accepted implementation intent and IaC binding are required");
+  }
+  const expectedIds = intent.resources.map(({ id }) => id).sort();
+  const bindingIds = Object.keys(binding.resourceBindings).sort();
+  const manifestIds = manifest.resources.map(({ logicalId }) => logicalId).sort();
+  return binding.track === expectedTrack &&
+    manifest.track === expectedTrack &&
+    JSON.stringify(bindingIds) === JSON.stringify(expectedIds) &&
+    JSON.stringify(manifestIds) === JSON.stringify(expectedIds)
+    ? []
+    : issue("/outputs/logical-resource-manifest", `${expectedTrack} binding coverage is incomplete`);
+}
+
+function comprehensiveReview(expectedNode: string, value: unknown): ValidationIssue[] {
+  const context = taskContext(value);
+  const review = context.outputs["review-findings"] as ReviewFindingsV1;
+  const subjectKind = expectedNode === "governance-reconciliation" ? "policy-property-map" : expectedNode;
+  const artifactKind = subjectKind === "plan" ? "implementation-intent" : subjectKind;
+  const expectedHash = context.artifactHashes[artifactKind];
+  const findingIds = review.findings.map(({ id }) => id);
+  if (new Set(findingIds).size !== findingIds.length) {
+    return issue("/outputs/review-findings/findings", "Review finding IDs must be unique");
+  }
+  return review.subjectKind === subjectKind && expectedHash !== undefined && review.subjectHash === expectedHash
+    ? []
+    : issue("/outputs/review-findings", `Review does not bind the accepted ${subjectKind} artifact`);
+}
+
+function requiredValidationEvidence(id: string, value: unknown): ValidationIssue[] {
+  const evidence = value as EvidenceManifestV1;
+  const matches = evidence.entries.filter(({ kind }) => kind === id);
+  return matches.length === 1 && matches[0]?.required === true && matches[0]?.retention === "immutable"
+    ? []
+    : issue("/entries", `Required immutable validation evidence is missing for ${id}`);
+}
+
+export function registerTaskWorkflowValidators(registry: ValidatorRegistry): void {
+  registry.register("schema:requirements-v1", RequirementsV1Schema);
+  registry.register("schema:architecture-v1", ArchitectureV1Schema);
+  registry.register("schema:governance-constraints-v1", GovernanceConstraintsV1Schema);
+  registry.register("schema:policy-property-map-v1", PolicyPropertyMapV1Schema);
+  registry.register("schema:implementation-intent-v1", ImplementationIntentV1Schema);
+  registry.register("schema:iac-binding-v1", IacBindingV1Schema);
+
+  registry.registerHandler("business:requirements-completeness", requirementsCompleteness);
+  registry.registerHandler("business:requirements-traceability", requirementsTraceability);
+  registry.registerHandler("business:cost-arithmetic", costArithmetic);
+  registry.registerHandler("business:governance-completeness", governanceCompleteness);
+  registry.registerHandler("business:governance-freshness", governanceFreshness, "freshness");
+  registry.registerHandler("business:policy-effect-coverage", policyEffectCoverage);
+  registry.registerHandler("business:plan-source-coverage", planSourceCoverage);
+  registry.registerHandler("business:binding-track-match", bindingTrackMatch);
+  registry.registerHandler("business:dependency-acyclic", dependencyAcyclic);
+  registry.registerHandler("business:bicep-binding-coverage", (value) => bindingCoverage("bicep", value));
+  registry.registerHandler("business:terraform-binding-coverage", (value) => bindingCoverage("terraform", value));
+
+  registry.registerHandler("review:requirements-comprehensive", (value) => comprehensiveReview("requirements", value));
+  registry.registerHandler("review:architecture-comprehensive", (value) => comprehensiveReview("architecture", value));
+  registry.registerHandler("review:governance-reconciliation", (value) =>
+    comprehensiveReview("governance-reconciliation", value),
+  );
+  registry.registerHandler("review:plan-comprehensive", (value) => comprehensiveReview("plan", value));
+
+  for (const id of VALIDATION_EVIDENCE_IDS) {
+    registry.registerHandler(id, (value) => requiredValidationEvidence(id, value));
+  }
+
+  const requiredBoundaries = new Set(["task-output", "review", "validation"]);
+  for (const [id, ownership] of WORKFLOW_VALIDATOR_OWNERSHIP) {
+    if (requiredBoundaries.has(ownership.boundary) && !registry.has(id)) {
+      throw new Error(`Workflow validator ${id} has no registered ${ownership.boundary} handler`);
+    }
+  }
+}
+
+export function taskWorkflowValidatorInput(id: string, context: WorkflowTaskValidatorContext): unknown {
+  const schemaInputs: Readonly<Record<string, string>> = {
+    "schema:requirements-v1": "requirements",
+    "schema:architecture-v1": "architecture",
+    "schema:governance-constraints-v1": "governance-constraints",
+    "schema:policy-property-map-v1": "policy-property-map",
+    "schema:implementation-intent-v1": "implementation-intent",
+    "schema:iac-binding-v1": "iac-binding",
+  };
+  const outputKind = schemaInputs[id];
+  if (outputKind !== undefined) return context.outputs[outputKind];
+  if (VALIDATION_EVIDENCE_IDS.has(id)) return context.outputs["validation-evidence"];
+  return context;
+}

--- a/packages/kernel/src/test/workflow.test.ts
+++ b/packages/kernel/src/test/workflow.test.ts
@@ -79,6 +79,11 @@ test("validator registry caches pure results by content and never caches freshne
   registry.register("pure", schema);
   registry.register("fresh", schema, "freshness");
   registry.register("auth", schema, "authorization");
+  registry.registerHandler("business", (value) =>
+    (value as { value?: unknown }).value === 1 ? [] : [{ path: "/value", message: "Expected one" }],
+  );
+  assert.equal(registry.has("business"), true);
+  assert.equal(registry.has("missing"), false);
   assert.equal(registry.validate("pure", { value: 1 }).cached, false);
   assert.equal(registry.validate("pure", { value: 1 }).cached, true);
   assert.equal(registry.validate("pure", { value: 2 }).cached, false);
@@ -87,4 +92,10 @@ test("validator registry caches pure results by content and never caches freshne
   assert.equal(registry.validate("fresh", { value: 1 }).cached, false);
   assert.equal(registry.validate("auth", { value: 1 }).cached, false);
   assert.equal(registry.validate("auth", { value: 1 }).cached, false);
+  assert.equal(registry.validate("business", { value: 1 }).valid, true);
+  assert.equal(registry.validate("business", { value: 1 }).cached, true);
+  const failed = registry.validate("business", { value: 2 });
+  assert.deepEqual(failed.issues, [{ path: "/value", message: "Expected one" }]);
+  failed.issues.length = 0;
+  assert.deepEqual(registry.validate("business", { value: 2 }).issues, [{ path: "/value", message: "Expected one" }]);
 });

--- a/packages/kernel/src/validator-registry.ts
+++ b/packages/kernel/src/validator-registry.ts
@@ -15,8 +15,10 @@ export interface ValidationResult {
   cached: boolean;
 }
 
+export type ValidatorHandler = (value: unknown) => ValidationIssue[];
+
 interface RegisteredValidator {
-  schema: TSchema;
+  handler: ValidatorHandler;
   kind: ValidatorKind;
 }
 
@@ -25,10 +27,26 @@ export class ValidatorRegistry {
   private readonly cache = new Map<string, Omit<ValidationResult, "cached">>();
 
   register(name: string, schema: TSchema, kind: ValidatorKind = "pure"): void {
+    this.registerHandler(
+      name,
+      (value) =>
+        [...Value.Errors(schema, value)].map((error) => ({
+          path: error.path,
+          message: error.message,
+        })),
+      kind,
+    );
+  }
+
+  registerHandler(name: string, handler: ValidatorHandler, kind: ValidatorKind = "pure"): void {
     if (this.validators.has(name)) {
       throw new Error(`Validator ${name} is already registered`);
     }
-    this.validators.set(name, { schema, kind });
+    this.validators.set(name, { handler, kind });
+  }
+
+  has(name: string): boolean {
+    return this.validators.has(name);
   }
 
   validate(name: string, value: unknown): ValidationResult {
@@ -41,15 +59,12 @@ export class ValidatorRegistry {
     if (cached !== undefined) {
       return { ...cached, issues: [...cached.issues], cached: true };
     }
-    const issues = [...Value.Errors(validator.schema, value)].map((error) => ({
-      path: error.path,
-      message: error.message,
-    }));
+    const issues = validator.handler(value);
     const result = { valid: issues.length === 0, issues };
     if (cacheKey !== undefined) {
-      this.cache.set(cacheKey, result);
+      this.cache.set(cacheKey, { ...result, issues: [...issues] });
     }
-    return { ...result, cached: false };
+    return { ...result, issues: [...issues], cached: false };
   }
 
   clearCache(): void {

--- a/packages/kernel/src/workflow-validator-ownership.ts
+++ b/packages/kernel/src/workflow-validator-ownership.ts
@@ -1,10 +1,23 @@
 export type WorkflowValidatorExecution = "schema" | "inline" | "capability" | "review" | "external-command";
+export type WorkflowValidatorBoundary =
+  | "task-output"
+  | "review"
+  | "external-evidence"
+  | "validation"
+  | "gate"
+  | "preview"
+  | "deploy"
+  | "inventory"
+  | "diagnosis"
+  | "quality"
+  | "terminal";
 
 export interface WorkflowValidatorOwnership {
   readonly id: string;
   readonly owner: "@apex/kernel" | "@apex/capabilities" | "@apex/cli";
   readonly entrypoint: string;
   readonly execution: WorkflowValidatorExecution;
+  readonly boundary: WorkflowValidatorBoundary;
 }
 
 interface OwnershipGroup extends Omit<WorkflowValidatorOwnership, "id"> {
@@ -22,12 +35,12 @@ const ownershipGroups: readonly OwnershipGroup[] = [
       "schema:requirements-v1",
     ],
     owner: "@apex/cli",
-    entrypoint: "ApexService.assertValid",
+    entrypoint: "ApexService.validateTaskValidators",
     execution: "schema",
+    boundary: "task-output",
   },
   {
     ids: [
-      "business:availability-current",
       "business:bicep-binding-coverage",
       "business:binding-track-match",
       "business:cost-arithmetic",
@@ -36,20 +49,28 @@ const ownershipGroups: readonly OwnershipGroup[] = [
       "business:governance-freshness",
       "business:plan-source-coverage",
       "business:policy-effect-coverage",
-      "business:policy-property-map",
       "business:requirements-completeness",
       "business:requirements-traceability",
       "business:terraform-binding-coverage",
     ],
     owner: "@apex/cli",
-    entrypoint: "ApexService.completeTask",
+    entrypoint: "ApexService.validateTaskValidators",
     execution: "inline",
+    boundary: "task-output",
   },
   {
-    ids: ["business:logical-resource-parity", "business:security-baseline"],
+    ids: ["business:availability-current"],
+    owner: "@apex/cli",
+    entrypoint: "ApexService.completeTask",
+    execution: "capability",
+    boundary: "external-evidence",
+  },
+  {
+    ids: ["business:logical-resource-parity", "business:policy-property-map", "business:security-baseline"],
     owner: "@apex/capabilities",
     entrypoint: "validateGeneratedTree",
     execution: "capability",
+    boundary: "validation",
   },
   {
     ids: [
@@ -59,86 +80,100 @@ const ownershipGroups: readonly OwnershipGroup[] = [
       "review:requirements-comprehensive",
     ],
     owner: "@apex/cli",
-    entrypoint: "ApexService.reviewBlockers",
+    entrypoint: "ApexService.validateTaskValidators",
     execution: "review",
+    boundary: "review",
   },
   {
     ids: ["gate:architecture-cost-governance-ready", "gate:implementation-plan-ready", "gate:requirements-ready"],
     owner: "@apex/cli",
     entrypoint: "ApexService.route",
     execution: "inline",
+    boundary: "gate",
   },
   {
     ids: ["gate:approval-binding-complete", "gate:no-hard-blockers", "gate:preview-current"],
     owner: "@apex/cli",
     entrypoint: "ApexService.assertPreviewReady",
     execution: "inline",
+    boundary: "gate",
   },
   {
     ids: ["bicep:build", "bicep:format", "bicep:lint"],
     owner: "@apex/capabilities",
     entrypoint: "validateGeneratedTree",
     execution: "external-command",
+    boundary: "validation",
   },
   {
     ids: ["terraform:format", "terraform:init-backend-false", "terraform:validate"],
     owner: "@apex/capabilities",
     entrypoint: "validateGeneratedTree",
     execution: "external-command",
+    boundary: "validation",
   },
   {
     ids: ["terraform:saved-plan-binding"],
     owner: "@apex/capabilities",
     entrypoint: "NativeTerraformProvider.previewApply",
     execution: "capability",
+    boundary: "preview",
   },
   {
     ids: ["preview:coverage", "preview:freshness", "preview:hash-bindings", "preview:policy-precheck"],
     owner: "@apex/cli",
     entrypoint: "ApexService.assertPreviewReady",
     execution: "inline",
+    boundary: "preview",
   },
   {
     ids: ["deploy:exact-approved-operation", "deploy:stale-writer-rejection"],
     owner: "@apex/cli",
     entrypoint: "ApexService.deploy",
     execution: "inline",
+    boundary: "deploy",
   },
   {
     ids: ["deploy:bicep-stack-ownership"],
     owner: "@apex/capabilities",
     entrypoint: "NativeBicepProvider.apply",
     execution: "capability",
+    boundary: "deploy",
   },
   {
     ids: ["deploy:exact-saved-plan", "deploy:state-lineage-and-serial"],
     owner: "@apex/capabilities",
     entrypoint: "NativeTerraformProvider.apply",
     execution: "capability",
+    boundary: "deploy",
   },
   {
     ids: ["inventory:eventual-consistency-reconciled", "inventory:secret-free", "inventory:source-coverage"],
     owner: "@apex/cli",
     entrypoint: "ApexService.inventory",
     execution: "inline",
+    boundary: "inventory",
   },
   {
     ids: ["diagnosis:read-only", "diagnosis:secret-free"],
     owner: "@apex/cli",
     entrypoint: "ApexService.diagnose",
     execution: "inline",
+    boundary: "diagnosis",
   },
   {
     ids: ["quality:no-subjective-deterministic-claims", "quality:scorecard-decidable"],
     owner: "@apex/cli",
     entrypoint: "evaluateQuality",
     execution: "inline",
+    boundary: "quality",
   },
   {
     ids: ["terminal:run-evidence-complete"],
     owner: "@apex/cli",
     entrypoint: "ApexService.status",
     execution: "inline",
+    boundary: "terminal",
   },
 ];
 

--- a/packages/testkit/src/qualification.ts
+++ b/packages/testkit/src/qualification.ts
@@ -366,7 +366,12 @@ async function completeCreativeWorkflow(context: TrackContext): Promise<void> {
   ]);
   await context.service.decideGateNumber(2, "approved", "qualification");
   restart(context);
-  const plan = planBundle(context);
+  const plan = planBundle(context, {
+    requirements: requirementHashes.requirements!,
+    architecture: architectureHashes.architecture!,
+    "governance-constraints": governanceHashes["governance-constraints"]!,
+    "policy-property-map": policyHashes["policy-property-map"]!,
+  });
   const planHashes = await complete(context.service, "plan", plan);
   await complete(context.service, "plan-review", [
     { kind: "review-findings", value: review(context, "plan", planHashes["implementation-intent"]!) },
@@ -416,12 +421,12 @@ function requirementsFor(id: string) {
     unknowns: [],
   };
 }
-function intentFor(id: string, runId: string) {
+function intentFor(id: string, runId: string, sourceHashes: Record<string, string>) {
   return {
     schemaVersion: CONTRACT_VERSION,
     projectId: id,
     runId,
-    sourceHashes: { requirements: HASH },
+    sourceHashes,
     resources: [{ id: "api", type: "fake/service", purpose: "Serve requests", dependsOn: [], controls: [] }],
     outputs: ["endpoint"],
   };
@@ -504,8 +509,8 @@ function policyMap(context: TrackContext, governanceHash: string) {
     mappings: [],
   };
 }
-function planBundle(context: TrackContext): TaskOutput[] {
-  const intent = intentFor(projectId(context.track), context.runId);
+function planBundle(context: TrackContext, sourceHashes: Record<string, string>): TaskOutput[] {
+  const intent = intentFor(projectId(context.track), context.runId, sourceHashes);
   return [
     { kind: "implementation-intent", value: intent },
     {
@@ -572,12 +577,17 @@ function codegenBundle(context: TrackContext, plan: TaskOutput[]): TaskOutput[] 
   ];
 }
 function validation(context: TrackContext) {
+  const validatorIds =
+    context.track === "bicep"
+      ? ["bicep:format", "bicep:build", "bicep:lint"]
+      : ["terraform:format", "terraform:init-backend-false", "terraform:validate"];
+  validatorIds.push("business:security-baseline", "business:policy-property-map", "business:logical-resource-parity");
   return {
     schemaVersion: CONTRACT_VERSION,
     projectId: projectId(context.track),
     runId: context.runId,
     createdAt: context.clock.now().toISOString(),
-    entries: [{ kind: "test", hash: HASH, bytes: 1, required: true, retention: "immutable" }],
+    entries: validatorIds.map((kind) => ({ kind, hash: HASH, bytes: 1, required: true, retention: "immutable" })),
   };
 }
 function diagnosis(context: TrackContext) {


### PR DESCRIPTION
## Summary
- extend the in-process validator registry with handwritten handlers and fail-closed coverage checks
- dispatch ordered task-output, review, and validation-bound IDs from the runtime workflow manifest
- persist successful validator IDs on `task.completed` events
- enforce source hashes, traceability, freshness, DAG, review, binding, and validator-specific evidence semantics
- keep gate, preview/deploy, inventory, diagnosis, quality, terminal, and availability boundaries explicit for follow-on #542 slices

## Validation
- targeted mutation and journal characterization tests
- full `npm run test:vnext`
- `npm run validate:vnext`
- targeted Prettier and cache-free ESLint
- independent boundary audit: 55 declared IDs; all 30 task/review/validation IDs covered

Tracks #561
Parent #542