### PR TITLE
feat: enforce workflow gate validators

### DIFF
--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -87,8 +87,9 @@ import { basename, delimiter, isAbsolute, join, relative, resolve, sep } from "n
 import { resolveBundledAssets } from "./assets.js";
 import { ApexError, EXIT_CODES } from "./errors.js";
 import {
-  registerTaskWorkflowValidators,
+  registerWorkflowValidators,
   taskWorkflowValidatorInput,
+  type WorkflowGateValidatorContext,
   type WorkflowTaskValidatorContext,
 } from "./workflow-validators.js";
 
@@ -289,7 +290,7 @@ export class ApexService {
     for (const [, [validator, schema]] of Object.entries(ARTIFACTS)) this.validators.register(validator, schema);
     this.validators.register("approval", ApprovalEvidenceV1Schema);
     this.validators.register("runtime-lock", RuntimeBundleLockV1Schema);
-    registerTaskWorkflowValidators(this.validators);
+    registerWorkflowValidators(this.validators);
     this.providers = {
       fake: new FakeIaCProvider({ track: "bicep", now: this.clock, nextId: this.idSource }),
       ...options.providers,
@@ -911,26 +912,29 @@ export class ApexService {
         `${finding.severity} findings cannot be accepted as risk by default policy`,
         EXIT_CODES.authorization,
       );
-    const prior = events.find(
-      (event) =>
-        event.type === "review.resolved" &&
-        (event.payload as { resolution?: ReviewResolution }).resolution?.reviewHash === resolution.reviewHash &&
-        (event.payload as { resolution?: ReviewResolution }).resolution?.findingId === resolution.findingId,
+    const priorResolutions = events.flatMap((event) => {
+      if (event.type !== "review.resolved") return [];
+      const prior = (event.payload as { resolution?: ReviewResolution }).resolution;
+      return prior?.reviewHash === resolution.reviewHash && prior.findingId === resolution.findingId ? [prior] : [];
+    });
+    if (priorResolutions.some((prior) => sha256Json(prior) === sha256Json(resolution))) return;
+    const hasCurrentResolution = priorResolutions.some(
+      (prior) =>
+        prior.disposition === "fixed" ||
+        (prior.expiresAt !== undefined && Date.parse(prior.expiresAt) > this.clock().getTime()),
     );
-    if (prior !== undefined) {
-      if (sha256Json((prior.payload as { resolution: ReviewResolution }).resolution) === sha256Json(resolution)) return;
+    if (hasCurrentResolution)
       throw new ApexError("APEX_CONFLICT", "Finding already has a conflicting resolution", EXIT_CODES.conflict);
-    }
     await this.append(run, "review.resolved", { resolution: resolution as unknown as JsonValue });
     const updatedEvents = await this.journal(run).replay();
     const nodeId = reviewPayload.nodeId;
     const descriptor = typeof nodeId === "string" ? TASKS.find(({ id }) => id === nodeId) : undefined;
-    if (
-      descriptor?.gate !== undefined &&
-      this.reviewBlockers(updatedEvents, descriptor.id).length === 0 &&
-      !this.gateApproved(await this.currentRun(), descriptor.gate)
-    ) {
-      await this.openRunGate(await this.currentRun(), descriptor.gate, resolution.dependencyHash);
+    if (descriptor?.gate !== undefined && this.reviewBlockers(updatedEvents, descriptor.id).length === 0) {
+      const current = await this.currentRun();
+      const gateState = current.gates.find(({ gate }) => gate === descriptor.gate)?.state;
+      if (gateState === "closed" || gateState === "invalidated") {
+        await this.openRunGate(current, descriptor.gate, resolution.dependencyHash);
+      }
     }
   }
 
@@ -985,6 +989,7 @@ export class ApexService {
       ...(gateNumber === 4 ? { expiresAt: new Date(this.clock().getTime() + PREVIEW_TTL_MS).toISOString() } : {}),
     };
     this.assertValid("approval", approval);
+    const validatorIds = decision === "approved" ? await this.validateGateValidators(run, gate, events, approval) : [];
     const approvalHash = await this.objects.putJson(approval);
     const updated = {
       ...run,
@@ -994,6 +999,7 @@ export class ApexService {
       gate: gateNumber,
       approvalHash,
       ...(previewHash === undefined ? {} : { previewHash }),
+      ...(validatorIds.length === 0 ? {} : { validatorIds }),
     });
     return approval;
   }
@@ -2105,6 +2111,86 @@ export class ApexService {
     for (const id of validatorIds) {
       this.assertValid(id, taskWorkflowValidatorInput(id, context));
     }
+    return validatorIds;
+  }
+
+  private async validateGateValidators(
+    run: RunConfigV1,
+    gate: RunConfigV1["gates"][number],
+    events: Awaited<ReturnType<EventJournal["replay"]>>,
+    approval: ApprovalEvidenceV1,
+  ): Promise<string[]> {
+    const workflow = new WorkflowEngine(
+      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
+    );
+    const nodeId = `gate-${gate.gate}`;
+    const node = workflow.manifest.nodes.find(({ id }) => id === nodeId);
+    if (node === undefined) throw new Error(`Workflow gate ${nodeId} has no manifest node`);
+    const validatorIds = node.validators.filter((id) => workflowValidatorOwnership(id)?.boundary === "gate");
+
+    const artifactHashes: Record<string, string> = {};
+    for (const event of events) {
+      if (event.type !== "task.completed") continue;
+      const hashes = (event.payload as { artifactHashes?: Record<string, unknown> }).artifactHashes ?? {};
+      for (const [kind, hash] of Object.entries(hashes)) if (typeof hash === "string") artifactHashes[kind] = hash;
+    }
+    const completedNodes = [...this.completedNodeIds(events)].sort();
+    const reviewNodesByGate: Record<number, string[]> = {
+      1: ["requirements-review"],
+      2: ["architecture-review", "governance-review"],
+      3: ["plan-review"],
+      4: ["requirements-review", "architecture-review", "governance-review", "plan-review"],
+    };
+    let reviewNodes = reviewNodesByGate[gate.gate] ?? [];
+    let legacyRequirements = false;
+    let expectedDependencyHash: string | undefined;
+    const dependencyReview = { 1: "requirements-review", 2: "governance-review", 3: "plan-review" }[gate.gate];
+    if (dependencyReview !== undefined) {
+      expectedDependencyHash = this.latestPayloadHash(
+        events,
+        "task.completed",
+        "dependencyHash",
+        (payload) => payload.nodeId === dependencyReview,
+      );
+    }
+    if (gate.gate === 1 && expectedDependencyHash === undefined) {
+      const legacyEvent = [...events]
+        .reverse()
+        .find(
+          (event) =>
+            event.type === "task.completed" &&
+            (event.payload as { nodeId?: unknown; legacy?: unknown }).nodeId === "requirements" &&
+            (event.payload as { legacy?: unknown }).legacy === true,
+        );
+      const hashes = (legacyEvent?.payload as { artifactHashes?: Record<string, string> } | undefined)?.artifactHashes;
+      if (hashes !== undefined) {
+        legacyRequirements = true;
+        reviewNodes = [];
+        expectedDependencyHash = sha256Json(hashes);
+      }
+    }
+
+    let preview: DeploymentPreviewV1 | undefined;
+    if (gate.gate === 4) {
+      const previewObjectHash = this.latestPayloadHash(events, "preview.created", "previewObjectHash");
+      if (previewObjectHash !== undefined) preview = await this.objects.getJson<DeploymentPreviewV1>(previewObjectHash);
+      expectedDependencyHash = preview?.previewHash;
+    }
+    const context: WorkflowGateValidatorContext = {
+      gateNumber: gate.gate,
+      now: this.clock().toISOString(),
+      run,
+      gate,
+      approval,
+      artifactHashes,
+      completedNodes,
+      reviewBlockers: reviewNodes.flatMap((reviewNode) => this.reviewBlockers(events, reviewNode)),
+      currentDependencyRevision: this.dependencyRevision(run, events),
+      legacyRequirements,
+      ...(expectedDependencyHash === undefined ? {} : { expectedDependencyHash }),
+      ...(preview === undefined ? {} : { preview }),
+    };
+    for (const id of validatorIds) this.assertValid(id, context);
     return validatorIds;
   }
 

--- a/packages/cli/src/test/expanded-workflow.test.ts
+++ b/packages/cli/src/test/expanded-workflow.test.ts
@@ -122,6 +122,30 @@ test("task completion records executed manifest validators in order", async () =
   ]);
 });
 
+test("gate approval records executed manifest validators in order", async () => {
+  const root = await tempRoot();
+  const service = new ApexService(root);
+  const { runId } = await service.init({ projectId: "demo" });
+  await service.nextTask();
+  const requirementHashes = await complete(service, "requirements", [
+    { kind: "requirements", value: requirements() },
+    { kind: "sku-manifest", value: skuManifest(sha256Json(requirements())) },
+  ]);
+  await complete(service, "requirements-review", [
+    {
+      kind: "review-findings",
+      value: review(runId, "requirements", requirementHashes.requirements!),
+    },
+  ]);
+  await service.decideGateNumber(1, "approved", "tester");
+
+  const events = await new EventJournal(join(root, ".apex", "projects", "demo", "runs", runId, "journal")).replay();
+  const decided = events.find(
+    (event) => event.type === "gate.decided" && (event.payload as { gate?: unknown }).gate === 1,
+  );
+  assert.deepEqual((decided?.payload as { validatorIds?: unknown }).validatorIds, ["gate:requirements-ready"]);
+});
+
 test("task-bound workflow validators reject semantic and evidence mutations", async () => {
   const root = await tempRoot();
   const service = new ApexService(root);
@@ -388,6 +412,53 @@ test("review blockers persist, resolve, and permit gate approval", async () => {
   assert.equal((await restarted.status()).run.gates[0]?.state, "open");
   await restarted.decideGateNumber(1, "approved", "tester");
   assert.equal((await restarted.nextTask()).status, "task");
+});
+
+test("expired accepted risk can be replaced without reopening an open gate", async () => {
+  let now = Date.parse("2026-01-01T00:00:00.000Z");
+  const service = new ApexService(await tempRoot(), { clock: () => new Date(now) });
+  const { runId } = await service.init({ projectId: "demo" });
+  await service.nextTask();
+  const hashes = await complete(service, "requirements", [
+    { kind: "requirements", value: requirements() },
+    { kind: "sku-manifest", value: skuManifest(sha256Json(requirements())) },
+  ]);
+  const reviewHashes = await complete(service, "requirements-review", [
+    {
+      kind: "review-findings",
+      value: review(runId, "requirements", hashes.requirements!, [
+        { id: "F-1", severity: "medium", disposition: "open", title: "Risk", detail: "Resolve", evidenceRefs: [] },
+      ]),
+    },
+  ]);
+  const dependencyHash = sha256Json({ "review-findings": reviewHashes["review-findings"]! });
+  await service.resolveReview({
+    findingId: "F-1",
+    reviewHash: reviewHashes["review-findings"]!,
+    subjectHash: hashes.requirements!,
+    disposition: "accepted-risk",
+    actor: "tester",
+    rationale: "temporary exception",
+    evidenceRefs: [],
+    expiresAt: "2026-01-02T00:00:00.000Z",
+    dependencyHash,
+  });
+  assert.equal((await service.status()).run.gates[0]?.state, "open");
+
+  now = Date.parse("2026-01-03T00:00:00.000Z");
+  await assert.rejects(service.decideGateNumber(1, "approved", "tester"), /gate:requirements-ready/);
+  await service.resolveReview({
+    findingId: "F-1",
+    reviewHash: reviewHashes["review-findings"]!,
+    subjectHash: hashes.requirements!,
+    disposition: "fixed",
+    actor: "tester",
+    rationale: "permanent correction",
+    evidenceRefs: [hashes.requirements!],
+    dependencyHash,
+  });
+  assert.equal((await service.status()).run.gates[0]?.state, "open");
+  await service.decideGateNumber(1, "approved", "tester");
 });
 
 test("promotion inherits neutral progression and restarts at the first environment-specific dependency", async () => {

--- a/packages/cli/src/test/workflow.test.ts
+++ b/packages/cli/src/test/workflow.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
+import { EventJournal } from "@apex/kernel";
 import { ApexError } from "../errors.js";
 import { ApexService } from "../service.js";
 import { prepareValidatedRun, requirements, tempRoot } from "./helpers.js";
@@ -13,6 +14,29 @@ test("full requirements to fake deploy workflow survives restart", async () => {
   await prepareValidatedRun(service, initialized.runId, "bicep");
   const preview = await service.preview({ operation: "apply", provider: "fake" });
   await service.decideGateNumber(4, "approved", "tester");
+  const events = await new EventJournal(
+    join(root, ".apex", "projects", "demo", "runs", initialized.runId, "journal"),
+  ).replay();
+  const gateValidators = new Map(
+    events.flatMap((event) =>
+      event.type === "gate.decided"
+        ? [
+            [
+              (event.payload as { gate: number }).gate,
+              (event.payload as { validatorIds?: unknown }).validatorIds,
+            ] as const,
+          ]
+        : [],
+    ),
+  );
+  assert.deepEqual(gateValidators.get(1), ["gate:requirements-ready"]);
+  assert.deepEqual(gateValidators.get(2), ["gate:architecture-cost-governance-ready"]);
+  assert.deepEqual(gateValidators.get(3), ["gate:implementation-plan-ready"]);
+  assert.deepEqual(gateValidators.get(4), [
+    "gate:preview-current",
+    "gate:approval-binding-complete",
+    "gate:no-hard-blockers",
+  ]);
   const deployed = await service.deploy(preview.previewHash);
   assert.equal(deployed.inventory.resources.length, 1);
 
@@ -66,6 +90,47 @@ test("expired preview and wrong preview hash are rejected", async () => {
     service.deploy(preview.previewHash),
     (error: unknown) => error instanceof ApexError && error.code === "APEX_STALE",
   );
+});
+
+test("gate approval rejects stale dependencies while explicit rejection remains available", async () => {
+  const root = await tempRoot();
+  const service = new ApexService(root);
+  const initialized = await service.init({ projectId: "demo" });
+  await service.nextTask();
+  const issued = await service.nextTask();
+  assert.equal(issued.status, "task");
+  if (issued.status !== "task") return;
+  await service.completeTask(issued.task.taskId, { kind: "requirements", value: requirements() });
+
+  const runPath = join(root, ".apex", "projects", "demo", "runs", initialized.runId, "run.json");
+  const run = JSON.parse(await readFile(runPath, "utf8")) as { gates: Array<{ gate: number; dependencyHash: string }> };
+  await writeFile(
+    runPath,
+    JSON.stringify({
+      ...run,
+      gates: run.gates.map((gate) => (gate.gate === 1 ? { ...gate, dependencyHash: "f".repeat(64) } : gate)),
+    }),
+  );
+  await assert.rejects(service.decideGateNumber(1, "approved", "tester"), /gate:requirements-ready/);
+  const rejection = await service.decideGateNumber(1, "rejected", "tester");
+  assert.equal(rejection.decision, "rejected");
+
+  const events = await new EventJournal(
+    join(root, ".apex", "projects", "demo", "runs", initialized.runId, "journal"),
+  ).replay();
+  const decided = events.find((event) => event.type === "gate.decided");
+  assert.equal((decided?.payload as { validatorIds?: unknown }).validatorIds, undefined);
+});
+
+test("Gate 4 approval rejects an expired preview before changing gate state", async () => {
+  let now = Date.parse("2026-01-01T00:00:00.000Z");
+  const service = new ApexService(await tempRoot(), { clock: () => new Date(now) });
+  const initialized = await service.init({ projectId: "demo" });
+  await prepareValidatedRun(service, initialized.runId, "bicep");
+  await service.preview({ operation: "apply", provider: "fake", expiresInMs: 1 });
+  now += 2;
+  await assert.rejects(service.decideGateNumber(4, "approved", "tester"), /gate:preview-current/);
+  assert.equal((await service.status()).run.gates[3]?.state, "open");
 });
 
 test("deploy rejects a preview and approval from an older owner epoch", async () => {

--- a/packages/cli/src/workflow-validators.ts
+++ b/packages/cli/src/workflow-validators.ts
@@ -6,9 +6,11 @@ import {
   PolicyPropertyMapV1Schema,
   RequirementsV1Schema,
   hasValidCostArithmetic,
+  type ApprovalEvidenceV1,
   type ArchitectureV1,
   type CostEstimateV1,
   type EvidenceManifestV1,
+  type GateRecordV1,
   type GovernanceConstraintsV1,
   type IacBindingV1,
   type ImplementationIntentV1,
@@ -16,6 +18,8 @@ import {
   type PolicyPropertyMapV1,
   type RequirementsV1,
   type ReviewFindingsV1,
+  type RunConfigV1,
+  type DeploymentPreviewV1,
 } from "@apex/contracts";
 import { WORKFLOW_VALIDATOR_OWNERSHIP, sha256Json, type ValidationIssue, type ValidatorRegistry } from "@apex/kernel";
 
@@ -26,6 +30,21 @@ export interface WorkflowTaskValidatorContext {
   readonly outputs: Readonly<Record<string, unknown>>;
   readonly artifacts: Readonly<Record<string, unknown>>;
   readonly artifactHashes: Readonly<Record<string, string>>;
+}
+
+export interface WorkflowGateValidatorContext {
+  readonly gateNumber: number;
+  readonly now: string;
+  readonly run: RunConfigV1;
+  readonly gate: GateRecordV1;
+  readonly approval: ApprovalEvidenceV1;
+  readonly artifactHashes: Readonly<Record<string, string>>;
+  readonly completedNodes: readonly string[];
+  readonly reviewBlockers: readonly string[];
+  readonly expectedDependencyHash?: string;
+  readonly currentDependencyRevision: string;
+  readonly legacyRequirements: boolean;
+  readonly preview?: DeploymentPreviewV1;
 }
 
 const VALIDATION_EVIDENCE_IDS = new Set([
@@ -225,7 +244,112 @@ function requiredValidationEvidence(id: string, value: unknown): ValidationIssue
     : issue("/entries", `Required immutable validation evidence is missing for ${id}`);
 }
 
-export function registerTaskWorkflowValidators(registry: ValidatorRegistry): void {
+function gateContext(value: unknown): WorkflowGateValidatorContext {
+  return value as WorkflowGateValidatorContext;
+}
+
+function gateReady(expectedGate: 1 | 2 | 3, value: unknown): ValidationIssue[] {
+  const context = gateContext(value);
+  const requiredArtifacts: Record<1 | 2 | 3, readonly string[]> = {
+    1: ["requirements", "sku-manifest"],
+    2: ["architecture", "cost-estimate", "governance-constraints", "policy-property-map"],
+    3: ["implementation-intent", "iac-binding", "environment-inputs"],
+  };
+  const requiredReviews: Record<1 | 2 | 3, readonly string[]> = {
+    1: context.legacyRequirements ? [] : ["requirements-review"],
+    2: ["architecture-review", "governance-review"],
+    3: ["plan-review"],
+  };
+  const issues: ValidationIssue[] = [];
+  if (context.gateNumber !== expectedGate || context.gate.gate !== expectedGate) {
+    issues.push({ path: "/gateNumber", message: `Expected Gate ${expectedGate}` });
+  }
+  if (context.gate.state !== "open") issues.push({ path: "/gate/state", message: "Gate is not open" });
+  const missingArtifacts = requiredArtifacts[expectedGate].filter((kind) => context.artifactHashes[kind] === undefined);
+  if (missingArtifacts.length > 0) {
+    issues.push({ path: "/artifactHashes", message: `Missing required artifacts: ${missingArtifacts.join(", ")}` });
+  }
+  const completed = new Set(context.completedNodes);
+  const missingReviews = requiredReviews[expectedGate].filter((nodeId) => !completed.has(nodeId));
+  if (missingReviews.length > 0) {
+    issues.push({ path: "/completedNodes", message: `Missing required reviews: ${missingReviews.join(", ")}` });
+  }
+  if (context.reviewBlockers.length > 0) {
+    issues.push({
+      path: "/reviewBlockers",
+      message: `Unresolved review findings: ${context.reviewBlockers.join(", ")}`,
+    });
+  }
+  if (context.expectedDependencyHash === undefined || context.gate.dependencyHash !== context.expectedDependencyHash) {
+    issues.push({ path: "/gate/dependencyHash", message: "Gate is not bound to the current review dependency" });
+  }
+  if (context.approval.dependencyHash !== context.gate.dependencyHash) {
+    issues.push({ path: "/approval/dependencyHash", message: "Approval is not bound to the open gate" });
+  }
+  return issues;
+}
+
+function gatePreviewCurrent(value: unknown): ValidationIssue[] {
+  const context = gateContext(value);
+  const preview = context.preview;
+  if (preview === undefined) return issue("/preview", "Current deployment preview is required");
+  const issues: ValidationIssue[] = [];
+  if (context.gateNumber !== 4 || context.gate.gate !== 4 || context.gate.state !== "open") {
+    issues.push({ path: "/gate", message: "Gate 4 is not open" });
+  }
+  if (context.gate.dependencyHash !== preview.previewHash) {
+    issues.push({ path: "/gate/dependencyHash", message: "Gate 4 is not bound to the current preview" });
+  }
+  if (
+    preview.projectId !== context.run.projectId ||
+    preview.runId !== context.run.runId ||
+    preview.track !== context.run.iacTool ||
+    preview.target !== context.run.targetScope
+  ) {
+    issues.push({ path: "/preview", message: "Preview identity does not match the selected run" });
+  }
+  if (
+    preview.dependencyRevision !== context.currentDependencyRevision ||
+    preview.commit !== context.currentDependencyRevision
+  ) {
+    issues.push({ path: "/preview/dependencyRevision", message: "Preview dependencies are stale" });
+  }
+  if (preview.ownerEpoch !== context.run.ownerEpoch) {
+    issues.push({ path: "/preview/ownerEpoch", message: "Preview writer epoch is stale" });
+  }
+  const now = Date.parse(context.now);
+  if (Date.parse(preview.createdAt) > now || Date.parse(preview.expiresAt) <= now) {
+    issues.push({ path: "/preview/expiresAt", message: "Preview is not current" });
+  }
+  return issues;
+}
+
+function gateApprovalBindingComplete(value: unknown): ValidationIssue[] {
+  const context = gateContext(value);
+  const preview = context.preview;
+  if (preview === undefined) return issue("/preview", "Current deployment preview is required");
+  const approval = context.approval;
+  const valid =
+    approval.gate === 4 &&
+    approval.decision === "approved" &&
+    approval.projectId === context.run.projectId &&
+    approval.runId === context.run.runId &&
+    approval.previewHash === preview.previewHash &&
+    approval.dependencyHash === preview.previewHash &&
+    approval.writerEpoch === context.run.ownerEpoch &&
+    approval.recipientIdentity !== undefined &&
+    approval.expiresAt !== undefined &&
+    Date.parse(approval.expiresAt) > Date.parse(context.now);
+  return valid ? [] : issue("/approval", "Approval does not completely bind the current preview and writer");
+}
+
+function gateNoHardBlockers(value: unknown): ValidationIssue[] {
+  const context = gateContext(value);
+  const blockers = [...(context.preview?.blockers ?? []), ...context.reviewBlockers];
+  return blockers.length === 0 ? [] : issue("/blockers", `Hard blockers remain: ${blockers.join(", ")}`);
+}
+
+export function registerWorkflowValidators(registry: ValidatorRegistry): void {
   registry.register("schema:requirements-v1", RequirementsV1Schema);
   registry.register("schema:architecture-v1", ArchitectureV1Schema);
   registry.register("schema:governance-constraints-v1", GovernanceConstraintsV1Schema);
@@ -256,7 +380,14 @@ export function registerTaskWorkflowValidators(registry: ValidatorRegistry): voi
     registry.registerHandler(id, (value) => requiredValidationEvidence(id, value));
   }
 
-  const requiredBoundaries = new Set(["task-output", "review", "validation"]);
+  registry.registerHandler("gate:requirements-ready", (value) => gateReady(1, value), "authorization");
+  registry.registerHandler("gate:architecture-cost-governance-ready", (value) => gateReady(2, value), "authorization");
+  registry.registerHandler("gate:implementation-plan-ready", (value) => gateReady(3, value), "authorization");
+  registry.registerHandler("gate:preview-current", gatePreviewCurrent, "authorization");
+  registry.registerHandler("gate:approval-binding-complete", gateApprovalBindingComplete, "authorization");
+  registry.registerHandler("gate:no-hard-blockers", gateNoHardBlockers, "authorization");
+
+  const requiredBoundaries = new Set(["task-output", "review", "validation", "gate"]);
   for (const [id, ownership] of WORKFLOW_VALIDATOR_OWNERSHIP) {
     if (requiredBoundaries.has(ownership.boundary) && !registry.has(id)) {
       throw new Error(`Workflow validator ${id} has no registered ${ownership.boundary} handler`);

--- a/packages/kernel/src/workflow-validator-ownership.ts
+++ b/packages/kernel/src/workflow-validator-ownership.ts
@@ -87,14 +87,14 @@ const ownershipGroups: readonly OwnershipGroup[] = [
   {
     ids: ["gate:architecture-cost-governance-ready", "gate:implementation-plan-ready", "gate:requirements-ready"],
     owner: "@apex/cli",
-    entrypoint: "ApexService.route",
+    entrypoint: "ApexService.validateGateValidators",
     execution: "inline",
     boundary: "gate",
   },
   {
     ids: ["gate:approval-binding-complete", "gate:no-hard-blockers", "gate:preview-current"],
     owner: "@apex/cli",
-    entrypoint: "ApexService.assertPreviewReady",
+    entrypoint: "ApexService.validateGateValidators",
     execution: "inline",
     boundary: "gate",
   },


### PR DESCRIPTION
## Summary
- execute all six manifest gate validators through non-cached authorization handlers
- bind Gates 1-3 to required artifacts, reviews, resolved findings, and current dependencies
- bind Gate 4 to the current preview, writer epoch, dependency revision, approval, and blocker state
- journal successful validator IDs in manifest order while preserving explicit rejection
- allow expired accepted-risk resolutions to be replaced without reopening an already-open gate

## Validation
- exact Gate 1-4 journal-order assertions
- stale dependency, expired preview, and expired-risk recovery regressions
- full `npm run test:vnext`
- `npm run validate:vnext`
- targeted Prettier and cache-free ESLint
- independent manifest coverage audit for all six gate IDs

Tracks #563
Parent #542