### PR TITLE
feat: enforce workflow preview validators

### DIFF
--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -90,6 +90,7 @@ import {
   registerWorkflowValidators,
   taskWorkflowValidatorInput,
   type WorkflowGateValidatorContext,
+  type WorkflowPreviewValidatorContext,
   type WorkflowTaskValidatorContext,
 } from "./workflow-validators.js";
 
@@ -1013,12 +1014,6 @@ export class ApexService {
     if (intentHash === undefined)
       throw new ApexError("APEX_VALIDATION", "Implementation intent is required", EXIT_CODES.validation);
     const intent = await this.objects.getJson<ImplementationIntentV1>(intentHash);
-    await this.append(run, "preview.requested", {
-      provider: options.provider,
-      operation: options.operation,
-      track: run.iacTool,
-      targetScope: run.targetScope,
-    });
     if (options.provider !== "fake") {
       if (options.provider !== run.iacTool) {
         throw new ApexError(
@@ -1059,23 +1054,39 @@ export class ApexService {
       const preview =
         options.operation === "apply" ? await provider.previewApply(request) : await provider.previewDestroy(request);
       this.assertValid("preview", preview);
-      const previewObjectHash = await this.objects.putJson(preview);
-      let attestationHash: string | undefined;
+      let attestation: ExecutionPlanAttestationV1 | undefined;
       if (options.provider === "terraform" && "attestation" in provider && typeof provider.attestation === "function") {
-        const attestation = (provider.attestation as (previewHash: string) => ExecutionPlanAttestationV1 | undefined)(
+        attestation = (provider.attestation as (previewHash: string) => ExecutionPlanAttestationV1 | undefined)(
           preview.previewHash,
         );
-        if (attestation !== undefined) {
-          this.assertValid("execution-plan-attestation", attestation);
-          attestationHash = await this.objects.putJson(attestation);
-        }
+        if (attestation !== undefined) this.assertValid("execution-plan-attestation", attestation);
       }
+      const validation = await this.validatePreviewValidators(
+        run,
+        events,
+        preview,
+        options.provider,
+        options.operation,
+        intent,
+        attestation,
+      );
+      const previewObjectHash = await this.objects.putJson(preview);
+      const attestationHash = attestation === undefined ? undefined : await this.objects.putJson(attestation);
+      await this.append(run, "preview.requested", {
+        provider: options.provider,
+        operation: options.operation,
+        track: run.iacTool,
+        targetScope: run.targetScope,
+      });
       await this.append(await this.currentRun(), "preview.created", {
         previewHash: preview.previewHash,
         previewObjectHash,
         provider: options.provider,
         providerRequestHash: sha256Json(request),
         commit: preview.commit,
+        validatorIds: validation.validatorIds,
+        evidenceMode: validation.evidenceMode,
+        ...(validation.omittedValidatorIds.length === 0 ? {} : { omittedValidatorIds: validation.omittedValidatorIds }),
         ...(attestationHash === undefined ? {} : { attestationHash }),
       });
       await this.openRunGate(await this.currentRun(), 4, preview.previewHash);
@@ -1095,7 +1106,7 @@ export class ApexService {
       ownerEpoch: run.ownerEpoch,
       inputHash: intentHash,
       iacHash: sha256Json(intent.resources),
-      policyHash: run.runtimeLockHash,
+      policyHash: this.artifactHash(events, "policy-property-map") ?? run.runtimeLockHash,
       changes: intent.resources.map((resource) => ({
         resourceId: `fake://${run.environment}/${resource.id}`,
         action: options.operation === "destroy" ? ("delete" as const) : ("create" as const),
@@ -1108,12 +1119,22 @@ export class ApexService {
     };
     const preview: DeploymentPreviewV1 = { ...base, previewHash: sha256Json(base) };
     this.assertValid("preview", preview);
+    const validation = await this.validatePreviewValidators(run, events, preview, "fake", options.operation, intent);
     const previewObjectHash = await this.objects.putJson(preview);
+    await this.append(run, "preview.requested", {
+      provider: options.provider,
+      operation: options.operation,
+      track: run.iacTool,
+      targetScope: run.targetScope,
+    });
     await this.append(run, "preview.created", {
       previewHash: preview.previewHash,
       previewObjectHash,
       provider: options.provider,
       commit: preview.commit,
+      validatorIds: validation.validatorIds,
+      evidenceMode: validation.evidenceMode,
+      ...(validation.omittedValidatorIds.length === 0 ? {} : { omittedValidatorIds: validation.omittedValidatorIds }),
     });
     await this.openRunGate(await this.currentRun(), 4, preview.previewHash);
     return preview;
@@ -2192,6 +2213,46 @@ export class ApexService {
     };
     for (const id of validatorIds) this.assertValid(id, context);
     return validatorIds;
+  }
+
+  private async validatePreviewValidators(
+    run: RunConfigV1,
+    events: Awaited<ReturnType<EventJournal["replay"]>>,
+    preview: DeploymentPreviewV1,
+    provider: "fake" | "bicep" | "terraform",
+    expectedOperation: "apply" | "destroy",
+    intent: ImplementationIntentV1,
+    attestation?: ExecutionPlanAttestationV1,
+  ): Promise<{ validatorIds: string[]; omittedValidatorIds: string[]; evidenceMode: "native" | "simulated" }> {
+    const workflow = new WorkflowEngine(
+      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
+    );
+    const nodeId = `preview-${run.iacTool}`;
+    const node = workflow.manifest.nodes.find(({ id }) => id === nodeId);
+    if (node === undefined) throw new Error(`Workflow preview ${nodeId} has no manifest node`);
+    const declaredIds = node.validators.filter((id) => workflowValidatorOwnership(id)?.boundary === "preview");
+    const omittedValidatorIds: string[] =
+      provider === "fake" ? declaredIds.filter((id) => id === "terraform:saved-plan-binding") : [];
+    const validatorIds = declaredIds.filter((id) => !omittedValidatorIds.includes(id));
+    const context: WorkflowPreviewValidatorContext = {
+      now: this.clock().toISOString(),
+      run,
+      provider,
+      expectedOperation,
+      preview,
+      intent,
+      expectedInputHash: this.artifactHash(events, "implementation-intent") ?? sha256Json(intent),
+      expectedIacHash:
+        provider === "fake"
+          ? sha256Json(intent.resources)
+          : (this.artifactHash(events, "iac-handoff") ?? sha256Json(intent.resources)),
+      expectedPolicyHash: this.artifactHash(events, "policy-property-map") ?? run.runtimeLockHash,
+      currentDependencyRevision: this.dependencyRevision(run, events),
+      expectedResourceIds: intent.resources.map(({ id }) => `${provider}://${run.environment}/${id}`),
+      ...(attestation === undefined ? {} : { attestation }),
+    };
+    for (const id of validatorIds) this.assertValid(id, context);
+    return { validatorIds, omittedValidatorIds, evidenceMode: provider === "fake" ? "simulated" : "native" };
   }
 
   private initialSkuManifest(run: RunConfigV1, requirements: unknown): unknown {

--- a/packages/cli/src/test/expanded-workflow.test.ts
+++ b/packages/cli/src/test/expanded-workflow.test.ts
@@ -3,7 +3,14 @@ import { join } from "node:path";
 import test from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import type { IacBindingV1, ImplementationIntentV1, LogicalResourceManifestV1 } from "@apex/contracts";
+import type {
+  DeploymentPreviewV1,
+  ExecutionPlanAttestationV1,
+  IacBindingV1,
+  ImplementationIntentV1,
+  LogicalResourceManifestV1,
+} from "@apex/contracts";
+import type { IacProvider, PreviewRequest } from "@apex/capabilities";
 import { EventJournal, sha256Json } from "@apex/kernel";
 import { ApexError } from "../errors.js";
 import { createMcpServer } from "../mcp.js";
@@ -100,6 +107,93 @@ async function reachValidation(service: ApexService, runId: string, track: "bice
   await complete(service, `validation-${track}`, [
     { kind: "validation-evidence", value: validationEvidence(runId, track) },
   ]);
+}
+
+function terraformPreviewProvider(
+  now: Date,
+  mutation?: "input-hash" | "operation" | "state",
+): IacProvider & {
+  attestation(previewHash: string): ExecutionPlanAttestationV1 | undefined;
+} {
+  let attestation: ExecutionPlanAttestationV1 | undefined;
+  const createPreview = async (request: PreviewRequest): Promise<DeploymentPreviewV1> => {
+    const plan = {
+      planDigest: "1".repeat(64),
+      configHash: "2".repeat(64),
+      lockfileHash: "3".repeat(64),
+      recipient: "local",
+      artifactRef: "plans/test.tfplan.enc",
+    };
+    const base = {
+      schemaVersion: "1.0.0" as const,
+      projectId: request.projectId,
+      runId: request.runId,
+      environment: request.environment as "dev",
+      track: "terraform" as const,
+      operation: (mutation === "operation" ? "destroy" : "apply") as "apply" | "destroy",
+      target: request.target,
+      commit: request.commit,
+      dependencyRevision: request.dependencyRevision,
+      ownerEpoch: request.ownerEpoch,
+      inputHash: mutation === "input-hash" ? "f".repeat(64) : request.inputHash,
+      iacHash: request.iacHash,
+      policyHash: request.policyHash,
+      artifactHash: sha256Json(plan),
+      stateLineage: "lineage-1",
+      stateSerial: 1,
+      changes: request.resources.map(({ resourceId }) => ({ resourceId, action: "create" as const, material: true })),
+      blockers: [],
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + request.ttlMs).toISOString(),
+    };
+    const preview = { ...base, previewHash: sha256Json(base) };
+    attestation = {
+      schemaVersion: "1.0.0",
+      projectId: request.projectId,
+      runId: request.runId,
+      track: "terraform",
+      previewHash: preview.previewHash,
+      inputHash: preview.inputHash,
+      iacHash: preview.iacHash,
+      policyHash: preview.policyHash,
+      configHash: plan.configHash,
+      lockfileHash: plan.lockfileHash,
+      recipient: plan.recipient,
+      planDigest: plan.planDigest,
+      artifactRef: plan.artifactRef,
+      stateLineage: mutation === "state" ? "lineage-other" : preview.stateLineage,
+      stateSerial: preview.stateSerial,
+      transport: {
+        encrypted: true,
+        implementation: "local-reference",
+        algorithm: "aes-256-gcm",
+        recipient: "local",
+        mediaType: "application/vnd.apex.terraform-plan",
+        iv: "iv",
+        authTag: "tag",
+      },
+      createdAt: now.toISOString(),
+      expiresAt: preview.expiresAt,
+    };
+    return preview;
+  };
+  return {
+    track: "terraform",
+    validate: async () => [],
+    previewApply: createPreview,
+    previewDestroy: createPreview,
+    apply: async () => {
+      throw new Error("not used");
+    },
+    destroy: async () => {
+      throw new Error("not used");
+    },
+    inventory: async () => {
+      throw new Error("not used");
+    },
+    reconcile: async () => undefined,
+    attestation: (previewHash) => (attestation?.previewHash === previewHash ? attestation : undefined),
+  };
 }
 
 test("task completion records executed manifest validators in order", async () => {
@@ -326,10 +420,26 @@ test("task-bound workflow validators reject semantic and evidence mutations", as
 
 for (const track of ["bicep", "terraform"] as const) {
   test(`full logical ${track} workflow reaches fake deploy and quality`, async () => {
-    const service = new ApexService(await tempRoot());
+    const root = await tempRoot();
+    const service = new ApexService(root);
     const { runId } = await service.init({ projectId: "demo", iacTool: track });
     await reachValidation(service, runId, track);
     const preview = await service.preview({ operation: "apply", provider: "fake" });
+    const previewEvents = await new EventJournal(
+      join(root, ".apex", "projects", "demo", "runs", runId, "journal"),
+    ).replay();
+    const previewCreated = [...previewEvents].reverse().find((event) => event.type === "preview.created");
+    assert.deepEqual((previewCreated?.payload as { validatorIds?: unknown }).validatorIds, [
+      "preview:hash-bindings",
+      "preview:policy-precheck",
+      "preview:coverage",
+      "preview:freshness",
+    ]);
+    assert.equal((previewCreated?.payload as { evidenceMode?: unknown }).evidenceMode, "simulated");
+    assert.deepEqual(
+      (previewCreated?.payload as { omittedValidatorIds?: unknown }).omittedValidatorIds,
+      track === "terraform" ? ["terraform:saved-plan-binding"] : undefined,
+    );
     await service.decideGateNumber(4, "approved", "tester");
     const deployed = await service.deploy(preview.previewHash);
     assert.equal(deployed.inventory.resources.length, 1);
@@ -363,6 +473,76 @@ for (const track of ["bicep", "terraform"] as const) {
     assert.equal((await service.status()).task, null);
   });
 }
+
+test("native Terraform preview records saved-plan validation and rejects wrong bindings", async () => {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  const root = await tempRoot();
+  const provider = terraformPreviewProvider(now);
+  const service = new ApexService(root, { clock: () => now, providers: { terraform: provider } });
+  const { runId } = await service.init({ projectId: "demo", iacTool: "terraform" });
+  await reachValidation(service, runId, "terraform");
+  await service.preview({ operation: "apply", provider: "terraform" });
+  const events = await new EventJournal(join(root, ".apex", "projects", "demo", "runs", runId, "journal")).replay();
+  const created = [...events].reverse().find((event) => event.type === "preview.created");
+  assert.deepEqual((created?.payload as { validatorIds?: unknown }).validatorIds, [
+    "preview:hash-bindings",
+    "preview:policy-precheck",
+    "preview:coverage",
+    "preview:freshness",
+    "terraform:saved-plan-binding",
+  ]);
+  assert.equal((created?.payload as { evidenceMode?: unknown }).evidenceMode, "native");
+  assert.match((created?.payload as { attestationHash?: string }).attestationHash!, /^[0-9a-f]{64}$/);
+
+  const invalidRoot = await tempRoot();
+  const invalid = new ApexService(invalidRoot, {
+    clock: () => now,
+    providers: { terraform: terraformPreviewProvider(now, "input-hash") },
+  });
+  const initialized = await invalid.init({ projectId: "demo", iacTool: "terraform" });
+  await reachValidation(invalid, initialized.runId, "terraform");
+  await assert.rejects(invalid.preview({ operation: "apply", provider: "terraform" }), /preview:hash-bindings/);
+  assert.equal((await invalid.status()).run.gates[3]?.state, "closed");
+  const invalidEvents = await new EventJournal(
+    join(invalidRoot, ".apex", "projects", "demo", "runs", initialized.runId, "journal"),
+  ).replay();
+  assert.equal(
+    invalidEvents.some(({ type }) => type === "preview.created"),
+    false,
+  );
+  assert.equal(
+    invalidEvents.some(({ type }) => type === "preview.requested"),
+    false,
+  );
+
+  const operationRoot = await tempRoot();
+  const wrongOperation = new ApexService(operationRoot, {
+    clock: () => now,
+    providers: { terraform: terraformPreviewProvider(now, "operation") },
+  });
+  const operationRun = await wrongOperation.init({ projectId: "demo", iacTool: "terraform" });
+  await reachValidation(wrongOperation, operationRun.runId, "terraform");
+  await assert.rejects(wrongOperation.preview({ operation: "apply", provider: "terraform" }), /preview:hash-bindings/);
+
+  const stateRoot = await tempRoot();
+  const wrongState = new ApexService(stateRoot, {
+    clock: () => now,
+    providers: { terraform: terraformPreviewProvider(now, "state") },
+  });
+  const stateRun = await wrongState.init({ projectId: "demo", iacTool: "terraform" });
+  await reachValidation(wrongState, stateRun.runId, "terraform");
+  await assert.rejects(
+    wrongState.preview({ operation: "apply", provider: "terraform" }),
+    /terraform:saved-plan-binding/,
+  );
+
+  const recovering = new ApexService(invalidRoot, {
+    clock: () => now,
+    providers: { terraform: terraformPreviewProvider(now) },
+  });
+  await recovering.preview({ operation: "apply", provider: "terraform" });
+  assert.equal((await recovering.status()).run.gates[3]?.state, "open");
+});
 
 test("review blockers persist, resolve, and permit gate approval", async () => {
   const root = await tempRoot();

--- a/packages/cli/src/workflow-validators.ts
+++ b/packages/cli/src/workflow-validators.ts
@@ -10,6 +10,7 @@ import {
   type ArchitectureV1,
   type CostEstimateV1,
   type EvidenceManifestV1,
+  type ExecutionPlanAttestationV1,
   type GateRecordV1,
   type GovernanceConstraintsV1,
   type IacBindingV1,
@@ -45,6 +46,21 @@ export interface WorkflowGateValidatorContext {
   readonly currentDependencyRevision: string;
   readonly legacyRequirements: boolean;
   readonly preview?: DeploymentPreviewV1;
+}
+
+export interface WorkflowPreviewValidatorContext {
+  readonly now: string;
+  readonly run: RunConfigV1;
+  readonly provider: "fake" | "bicep" | "terraform";
+  readonly expectedOperation: "apply" | "destroy";
+  readonly preview: DeploymentPreviewV1;
+  readonly intent: ImplementationIntentV1;
+  readonly expectedInputHash: string;
+  readonly expectedIacHash: string;
+  readonly expectedPolicyHash: string;
+  readonly currentDependencyRevision: string;
+  readonly expectedResourceIds: readonly string[];
+  readonly attestation?: ExecutionPlanAttestationV1;
 }
 
 const VALIDATION_EVIDENCE_IDS = new Set([
@@ -349,6 +365,107 @@ function gateNoHardBlockers(value: unknown): ValidationIssue[] {
   return blockers.length === 0 ? [] : issue("/blockers", `Hard blockers remain: ${blockers.join(", ")}`);
 }
 
+function previewContext(value: unknown): WorkflowPreviewValidatorContext {
+  return value as WorkflowPreviewValidatorContext;
+}
+
+function previewHashBindings(value: unknown): ValidationIssue[] {
+  const context = previewContext(value);
+  const preview = context.preview;
+  const { previewHash, ...body } = preview;
+  const issues: ValidationIssue[] = [];
+  if (sha256Json(body) !== previewHash) issues.push({ path: "/previewHash", message: "Preview hash is invalid" });
+  if (
+    preview.projectId !== context.run.projectId ||
+    preview.runId !== context.run.runId ||
+    preview.track !== context.run.iacTool ||
+    preview.environment !== context.run.environment ||
+    preview.target !== context.run.targetScope ||
+    preview.operation !== context.expectedOperation
+  ) {
+    issues.push({ path: "/preview", message: "Preview identity does not match the selected run" });
+  }
+  if (
+    preview.inputHash !== context.expectedInputHash ||
+    preview.iacHash !== context.expectedIacHash ||
+    preview.policyHash !== context.expectedPolicyHash
+  ) {
+    issues.push({ path: "/preview", message: "Preview does not bind the accepted input, IaC, and policy artifacts" });
+  }
+  if (preview.ownerEpoch !== context.run.ownerEpoch) {
+    issues.push({ path: "/ownerEpoch", message: "Preview writer epoch is stale" });
+  }
+  return issues;
+}
+
+function previewPolicyPrecheck(value: unknown): ValidationIssue[] {
+  const context = previewContext(value);
+  return context.preview.policyHash === context.expectedPolicyHash
+    ? []
+    : issue("/policyHash", "Preview policy precheck is not bound to the current policy artifact");
+}
+
+function previewCoverage(value: unknown): ValidationIssue[] {
+  const context = previewContext(value);
+  const changes = context.preview.changes;
+  const resourceIds = changes.map(({ resourceId }) => resourceId);
+  const issues: ValidationIssue[] = [];
+  if (new Set(resourceIds).size !== resourceIds.length) {
+    issues.push({ path: "/changes", message: "Preview contains duplicate resource changes" });
+  }
+  if (changes.some(({ action }) => action === "unknown")) {
+    issues.push({ path: "/changes", message: "Preview contains unknown resource actions" });
+  }
+  if (context.provider === "fake") {
+    const actual = [...resourceIds].sort();
+    const expected = [...context.expectedResourceIds].sort();
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      issues.push({ path: "/changes", message: "Fake preview does not cover every requested resource" });
+    }
+  }
+  return issues;
+}
+
+function previewFreshness(value: unknown): ValidationIssue[] {
+  const context = previewContext(value);
+  const preview = context.preview;
+  const now = Date.parse(context.now);
+  return preview.commit === context.currentDependencyRevision &&
+    preview.dependencyRevision === context.currentDependencyRevision &&
+    Date.parse(preview.createdAt) <= now &&
+    Date.parse(preview.expiresAt) > now
+    ? []
+    : issue("/preview", "Preview is stale or expired");
+}
+
+function terraformSavedPlanBinding(value: unknown): ValidationIssue[] {
+  const context = previewContext(value);
+  const attestation = context.attestation;
+  if (attestation === undefined) return issue("/attestation", "Terraform saved-plan attestation is required");
+  const preview = context.preview;
+  const providerArtifactHash = sha256Json({
+    planDigest: attestation.planDigest,
+    configHash: attestation.configHash,
+    lockfileHash: attestation.lockfileHash,
+    recipient: attestation.recipient,
+    artifactRef: attestation.artifactRef,
+  });
+  const valid =
+    attestation.projectId === preview.projectId &&
+    attestation.runId === preview.runId &&
+    attestation.track === "terraform" &&
+    attestation.previewHash === preview.previewHash &&
+    attestation.inputHash === preview.inputHash &&
+    attestation.iacHash === preview.iacHash &&
+    attestation.policyHash === preview.policyHash &&
+    attestation.stateLineage === preview.stateLineage &&
+    attestation.stateSerial === preview.stateSerial &&
+    attestation.recipient === attestation.transport.recipient &&
+    attestation.expiresAt === preview.expiresAt &&
+    preview.artifactHash === providerArtifactHash;
+  return valid ? [] : issue("/attestation", "Terraform saved plan is not bound to the exact preview");
+}
+
 export function registerWorkflowValidators(registry: ValidatorRegistry): void {
   registry.register("schema:requirements-v1", RequirementsV1Schema);
   registry.register("schema:architecture-v1", ArchitectureV1Schema);
@@ -387,7 +504,13 @@ export function registerWorkflowValidators(registry: ValidatorRegistry): void {
   registry.registerHandler("gate:approval-binding-complete", gateApprovalBindingComplete, "authorization");
   registry.registerHandler("gate:no-hard-blockers", gateNoHardBlockers, "authorization");
 
-  const requiredBoundaries = new Set(["task-output", "review", "validation", "gate"]);
+  registry.registerHandler("preview:hash-bindings", previewHashBindings);
+  registry.registerHandler("preview:policy-precheck", previewPolicyPrecheck);
+  registry.registerHandler("preview:coverage", previewCoverage);
+  registry.registerHandler("preview:freshness", previewFreshness, "freshness");
+  registry.registerHandler("terraform:saved-plan-binding", terraformSavedPlanBinding, "authorization");
+
+  const requiredBoundaries = new Set(["task-output", "review", "validation", "gate", "preview"]);
   for (const [id, ownership] of WORKFLOW_VALIDATOR_OWNERSHIP) {
     if (requiredBoundaries.has(ownership.boundary) && !registry.has(id)) {
       throw new Error(`Workflow validator ${id} has no registered ${ownership.boundary} handler`);

--- a/packages/kernel/src/workflow-validator-ownership.ts
+++ b/packages/kernel/src/workflow-validator-ownership.ts
@@ -122,7 +122,7 @@ const ownershipGroups: readonly OwnershipGroup[] = [
   {
     ids: ["preview:coverage", "preview:freshness", "preview:hash-bindings", "preview:policy-precheck"],
     owner: "@apex/cli",
-    entrypoint: "ApexService.assertPreviewReady",
+    entrypoint: "ApexService.validatePreviewValidators",
     execution: "inline",
     boundary: "preview",
   },


### PR DESCRIPTION
## Summary
- execute all four common preview validators before durable preview or Gate 4 mutation
- validate operation, identity, canonical hash, accepted input/IaC/policy bindings, resource coverage, writer epoch, dependency revision, and TTL
- execute native Terraform saved-plan binding against encrypted-plan attestation
- label fake-provider evidence as simulated and explicitly omit native saved-plan evidence
- pair requested/created events only after validation and support same-run recovery

## Validation
- fake Bicep/Terraform exact validator-order assertions
- native Terraform input, operation, state-lineage, and recovery mutations
- full `npm run test:vnext`
- `npm run validate:vnext`
- targeted Prettier and cache-free ESLint
- independent coverage audit for all five preview IDs

Tracks #565
Parent #542