### PR TITLE
feat: enforce workflow quality evidence

### DIFF
--- a/config/workflow.v1.json
+++ b/config/workflow.v1.json
@@ -522,7 +522,7 @@
         "resource-inventory-v1",
         "quality-scorecard"
       ],
-      "outputs": ["quality-report-v1", "run-lessons-v1"],
+      "outputs": ["quality-report-v1"],
       "validators": ["quality:scorecard-decidable", "quality:no-subjective-deterministic-claims"],
       "invalidates": []
     },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import { NativeBicepProvider, NativeTerraformProvider, ProcessRunner, type IacProvider } from "@apex/capabilities";
-import type { QualityScorecardV1 } from "@apex/contracts";
-import { EventJournal, atomicWriteJson, sha256Bytes, sha256Json } from "@apex/kernel";
+import { QualityMeasurementsV1Schema, type QualityMeasurementsV1, type QualityScorecardV1 } from "@apex/contracts";
+import { EventJournal, ValidatorRegistry, atomicWriteJson, sha256Bytes, sha256Json } from "@apex/kernel";
 import { evaluateQualityScorecard, renderQualityScorecardEvaluation, type ScorecardMeasurement } from "@apex/renderers";
 import { join, resolve } from "node:path";
 import { ApexError, EXIT_CODES, normalizeError } from "./errors.js";
@@ -201,29 +201,75 @@ interface QualityEvaluationArtifact {
   readonly evaluations: ReturnType<typeof evaluateQualityScorecard>;
 }
 
+type QualityMeasurementInput = ScorecardMeasurement & {
+  evidenceRefs?: readonly string[];
+  provenance?: { inputReportHashes?: readonly string[] };
+};
+
 async function evaluateQuality(root: string, flags: Flags): Promise<QualityEvaluationArtifact> {
   const assets = await resolveBundledAssets();
   const scorecardPath =
     typeof flags.scorecard === "string" ? resolve(flags.scorecard) : join(assets.config, "quality-scorecard.v1.json");
   const measurementPath = resolve(required(flags, "measurements"));
   const scorecard = JSON.parse(await readFile(scorecardPath, "utf8")) as QualityScorecardV1;
-  const measurementInput = JSON.parse(await readFile(measurementPath, "utf8")) as
-    readonly ScorecardMeasurement[] | { measurements?: readonly ScorecardMeasurement[] };
-  const measurements = Array.isArray(measurementInput)
-    ? measurementInput
-    : (measurementInput as { measurements?: readonly ScorecardMeasurement[] }).measurements;
-  if (!Array.isArray(measurements))
+  const measurementInput = JSON.parse(await readFile(measurementPath, "utf8")) as unknown;
+  const inputMeasurements: readonly QualityMeasurementInput[] | undefined = Array.isArray(measurementInput)
+    ? (measurementInput as QualityMeasurementInput[])
+    : measurementInput !== null && typeof measurementInput === "object"
+      ? (measurementInput as { measurements?: readonly QualityMeasurementInput[] }).measurements
+      : undefined;
+  if (inputMeasurements === undefined)
     throw new ApexError("APEX_USAGE", "Measurements file must be an array or contain measurements[]", EXIT_CODES.usage);
+  const measurements = inputMeasurements
+    .map((measurement) => ({
+      metric: measurement.metric,
+      scenario: measurement.scenario,
+      ...(measurement.value === undefined ? {} : { value: measurement.value }),
+      samples: measurement.samples,
+      evidenceRefs: [
+        ...new Set(
+          (measurement.evidenceRefs ?? measurement.provenance?.inputReportHashes ?? []).filter(
+            (reference): reference is string => typeof reference === "string",
+          ),
+        ),
+      ].sort(),
+    }))
+    .sort((left, right) =>
+      `${left.metric}\u0000${left.scenario}`.localeCompare(`${right.metric}\u0000${right.scenario}`),
+    );
+  const measurementSet: QualityMeasurementsV1 = { schemaVersion: "1.0.0", measurements };
+  const measurementRegistry = new ValidatorRegistry();
+  measurementRegistry.register("quality-measurements", QualityMeasurementsV1Schema);
+  const measurementValidation = measurementRegistry.validate("quality-measurements", measurementSet);
+  if (!measurementValidation.valid)
+    throw new ApexError(
+      "APEX_VALIDATION",
+      "Quality measurements validation failed",
+      EXIT_CODES.validation,
+      measurementValidation.issues,
+    );
+  const keys = measurements.map(({ metric, scenario }) => `${metric}\u0000${scenario}`);
+  if (new Set(keys).size !== keys.length)
+    throw new ApexError(
+      "APEX_VALIDATION",
+      "Quality measurements contain duplicate metric/scenario pairs",
+      EXIT_CODES.validation,
+    );
   const evaluations = evaluateQualityScorecard(scorecard, measurements);
   const artifact: QualityEvaluationArtifact = {
     schemaVersion: "1.0.0",
     scorecardHash: sha256Json(scorecard),
-    measurementsHash: sha256Json(measurements),
-    status: evaluations.some(({ decision }) => decision === "fail") ? "fail" : "pass",
+    measurementsHash: sha256Json(measurementSet),
+    status:
+      evaluations.some(({ decision }) => decision === "fail") ||
+      !evaluations.some(({ decision }) => decision === "pass")
+        ? "fail"
+        : "pass",
     evaluations,
   };
   const outputDirectory = join(root, ".apex", "quality");
   await mkdir(outputDirectory, { recursive: true });
+  await atomicWriteJson(join(outputDirectory, "measurements.json"), measurementSet);
   await atomicWriteJson(join(outputDirectory, "evaluation.json"), artifact);
   await writeFile(
     join(outputDirectory, "evaluation.md"),

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -15,6 +15,7 @@ import {
   LogicalResourceManifestV1Schema,
   OperationRecordV1Schema,
   PolicyPropertyMapV1Schema,
+  QualityMeasurementsV1Schema,
   QualityReportV1Schema,
   RequirementsV1Schema,
   ResourceInventoryV1Schema,
@@ -35,6 +36,8 @@ import {
   type ProjectId,
   type ResourceInventoryV1,
   type ReviewFindingsV1,
+  type QualityScorecardV1,
+  type QualityMeasurementsV1,
   type RunConfigV1,
   type RunId,
   type RuntimeBundleLockV1,
@@ -291,6 +294,7 @@ export class ApexService {
     for (const [, [validator, schema]] of Object.entries(ARTIFACTS)) this.validators.register(validator, schema);
     this.validators.register("approval", ApprovalEvidenceV1Schema);
     this.validators.register("runtime-lock", RuntimeBundleLockV1Schema);
+    this.validators.register("quality-measurements", QualityMeasurementsV1Schema);
     registerWorkflowValidators(this.validators);
     this.providers = {
       fake: new FakeIaCProvider({ track: "bicep", now: this.clock, nextId: this.idSource }),
@@ -2106,7 +2110,9 @@ export class ApexService {
         ? "review"
         : descriptor.id.startsWith("validation-")
           ? "validation"
-          : "task-output";
+          : descriptor.id === "quality"
+            ? "quality"
+            : "task-output";
     const validatorIds = node.validators.filter((id) => workflowValidatorOwnership(id)?.boundary === boundary);
     const run = await this.currentRun();
     const events = await this.journal(run).replay();
@@ -2128,11 +2134,40 @@ export class ApexService {
       outputs: Object.fromEntries(outputs.map(({ kind, value }) => [kind, value])),
       artifacts,
       artifactHashes,
+      ...(nodeId === "quality" ? await this.qualityValidatorContext() : {}),
     };
     for (const id of validatorIds) {
       this.assertValid(id, taskWorkflowValidatorInput(id, context));
     }
     return validatorIds;
+  }
+
+  private async qualityValidatorContext(): Promise<{
+    scorecard: QualityScorecardV1;
+    qualityMeasurements: QualityMeasurementsV1;
+  }> {
+    let qualityMeasurements: QualityMeasurementsV1;
+    try {
+      qualityMeasurements = JSON.parse(
+        await readFile(join(this.root, ".apex", "quality", "measurements.json"), "utf8"),
+      ) as QualityMeasurementsV1;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new ApexError(
+          "APEX_VALIDATION",
+          "Quality measurements are unavailable; run quality evaluate first",
+          EXIT_CODES.validation,
+        );
+      }
+      throw error;
+    }
+    this.assertValid("quality-measurements", qualityMeasurements);
+    return {
+      scorecard: JSON.parse(
+        await readFile(join(this.root, ".apex", "runtime", "quality-scorecard.v1.json"), "utf8"),
+      ) as QualityScorecardV1,
+      qualityMeasurements,
+    };
   }
 
   private async validateGateValidators(
@@ -2380,7 +2415,7 @@ export class ApexService {
   private assertValid(name: string, value: unknown): void {
     const result = this.validators.validate(name, value);
     const issues = result.issues.filter((issue) => !issue.message.startsWith("Unknown format 'date"));
-    const invalidDateTimes = this.invalidDateTimes(value);
+    const invalidDateTimes = name.startsWith("schema:") || !name.includes(":") ? this.invalidDateTimes(value) : [];
     if (issues.length > 0 || invalidDateTimes.length > 0) {
       throw new ApexError("APEX_VALIDATION", `${name} validation failed`, EXIT_CODES.validation, [
         ...issues,
@@ -2439,6 +2474,7 @@ export class ApexService {
       workflowHash: sha256Bytes(await readFile(join(runtimeRoot, "workflow.v1.json"))),
       defaultsHash: sha256Bytes(await readFile(join(runtimeRoot, "defaults.v1.json"))),
       validatorHash: sha256Bytes(await readFile(validatorPath)),
+      qualityScorecardHash: sha256Bytes(await readFile(join(runtimeRoot, "quality-scorecard.v1.json"))),
       requiredCapabilityPacks: [...new Set(requiredCapabilityPacks)].sort(),
     };
     this.assertValid("runtime-lock", lock);
@@ -2466,6 +2502,11 @@ export class ApexService {
         { id: "runtime-lock:workflow", expected: lock.workflowHash, path: join(runtimeRoot, "workflow.v1.json") },
         { id: "runtime-lock:defaults", expected: lock.defaultsHash, path: join(runtimeRoot, "defaults.v1.json") },
         { id: "runtime-lock:validators", expected: lock.validatorHash, path: validatorPath },
+        {
+          id: "runtime-lock:quality-scorecard",
+          expected: lock.qualityScorecardHash,
+          path: join(runtimeRoot, "quality-scorecard.v1.json"),
+        },
       ];
       const checks = await Promise.all(
         hashes.map(async (item): Promise<DoctorCheck> => {

--- a/packages/cli/src/test/customizations.test.ts
+++ b/packages/cli/src/test/customizations.test.ts
@@ -218,9 +218,14 @@ test("init writes a real runtime lock and doctor detects managed tampering", asy
     workflowHash: string;
     defaultsHash: string;
     validatorHash: string;
+    qualityScorecardHash: string;
     requiredCapabilityPacks: string[];
   };
-  assert.ok([lock.workflowHash, lock.defaultsHash, lock.validatorHash].every((hash) => /^[a-f0-9]{64}$/.test(hash)));
+  assert.ok(
+    [lock.workflowHash, lock.defaultsHash, lock.validatorHash, lock.qualityScorecardHash].every((hash) =>
+      /^[a-f0-9]{64}$/.test(hash),
+    ),
+  );
   assert.ok(lock.requiredCapabilityPacks.includes("azure-governance-discovery"));
   assert.equal((await service.status()).run.runId, initialized.runId);
   await writeFile(join(root, ".apex", "runtime", "defaults.v1.json"), "{}\n");
@@ -230,6 +235,9 @@ test("init writes a real runtime lock and doctor detects managed tampering", asy
   assert.equal(doctor.nextAction, "Run doctor --fix --yes to reinstall bundled managed files");
   const fixed = await service.doctor(true, true);
   assert.equal(fixed.checks.find(({ id }) => id === "runtime-lock:defaults")?.ok, true);
+  await writeFile(join(root, ".apex", "runtime", "quality-scorecard.v1.json"), "{}\n");
+  const scorecardDoctor = await service.doctor();
+  assert.equal(scorecardDoctor.checks.find(({ id }) => id === "runtime-lock:quality-scorecard")?.ok, false);
 });
 
 test("doctor leaves unrelated core routes unaffected and service reports required workflow packs", async () => {

--- a/packages/cli/src/test/expanded-workflow.test.ts
+++ b/packages/cli/src/test/expanded-workflow.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -22,11 +23,13 @@ import {
   governance,
   planBundle,
   policyMap,
+  qualityReport,
   requirements,
   review,
   skuManifest,
   tempRoot,
   validationEvidence,
+  writeJson,
 } from "./helpers.js";
 
 async function task(service: ApexService, expected: string): Promise<string> {
@@ -457,18 +460,69 @@ for (const track of ["bicep", "terraform"] as const) {
         },
       },
     ]);
-    await complete(service, "quality", [
-      {
-        kind: "quality-report",
-        value: {
-          schemaVersion: "1.0.0",
-          projectId: "demo",
-          runId,
-          evaluatedAt: "2026-01-01T00:00:00.000Z",
-          status: "pass",
-          checks: [{ id: "deploy", status: "pass", evidenceRefs: [] }],
-        },
-      },
+    const qualityTask = await task(service, "quality");
+    const report = await qualityReport(root, runId);
+    const staleScorecard = { ...report, scorecardHash: "f".repeat(64) };
+    await assert.rejects(
+      service.completeTaskOutputs(qualityTask, [{ kind: "quality-report", value: staleScorecard }]),
+      /quality:scorecard-decidable/,
+    );
+    await writeJson(join(root, ".apex", "quality", "measurements.json"), {
+      schemaVersion: "1.0.0",
+      measurements: [],
+    });
+    await assert.rejects(
+      service.completeTaskOutputs(qualityTask, [{ kind: "quality-report", value: report }]),
+      /quality:scorecard-decidable/,
+    );
+    await qualityReport(root, runId);
+    const reordered = structuredClone(report);
+    [reordered.checks[0], reordered.checks[1]] = [reordered.checks[1]!, reordered.checks[0]!];
+    await assert.rejects(
+      service.completeTaskOutputs(qualityTask, [{ kind: "quality-report", value: reordered }]),
+      /quality:no-subjective-deterministic-claims/,
+    );
+    const measurementPath = join(root, ".apex", "quality", "measurements.json");
+    const duplicatedMeasurements = JSON.parse(await readFile(measurementPath, "utf8")) as {
+      schemaVersion: "1.0.0";
+      measurements: Array<Record<string, unknown>>;
+    };
+    duplicatedMeasurements.measurements.push({ ...duplicatedMeasurements.measurements[0]! });
+    await writeJson(measurementPath, duplicatedMeasurements);
+    const duplicateMeasurementReport = {
+      ...report,
+      measurementsHash: sha256Json(duplicatedMeasurements),
+    };
+    await assert.rejects(
+      service.completeTaskOutputs(qualityTask, [{ kind: "quality-report", value: duplicateMeasurementReport }]),
+      /quality:no-subjective-deterministic-claims/,
+    );
+    await qualityReport(root, runId);
+    const inventedPass = structuredClone(report);
+    inventedPass.checks[0]!.status = "pass";
+    inventedPass.checks[0]!.detail = "target satisfied";
+    inventedPass.status = "pass";
+    await assert.rejects(
+      service.completeTaskOutputs(qualityTask, [{ kind: "quality-report", value: inventedPass }]),
+      /quality:scorecard-decidable/,
+    );
+    const unsupportedClaim = structuredClone(report);
+    const claimed = unsupportedClaim.checks.find(({ status }) => status !== "omitted")!;
+    claimed.evidenceRefs = [];
+    await assert.rejects(
+      service.completeTaskOutputs(qualityTask, [{ kind: "quality-report", value: unsupportedClaim }]),
+      /quality:no-subjective-deterministic-claims/,
+    );
+    await service.completeTaskOutputs(qualityTask, [{ kind: "quality-report", value: report }]);
+    const qualityEvents = await new EventJournal(
+      join(root, ".apex", "projects", "demo", "runs", runId, "journal"),
+    ).replay();
+    const qualityCompleted = [...qualityEvents]
+      .reverse()
+      .find((event) => event.type === "task.completed" && (event.payload as { nodeId?: unknown }).nodeId === "quality");
+    assert.deepEqual((qualityCompleted?.payload as { validatorIds?: unknown }).validatorIds, [
+      "quality:scorecard-decidable",
+      "quality:no-subjective-deterministic-claims",
     ]);
     assert.equal((await service.status()).task, null);
   });

--- a/packages/cli/src/test/helpers.ts
+++ b/packages/cli/src/test/helpers.ts
@@ -1,6 +1,12 @@
-import { CONTRACT_VERSION, type ImplementationIntentV1, type RequirementsV1 } from "@apex/contracts";
+import {
+  CONTRACT_VERSION,
+  type ImplementationIntentV1,
+  type QualityScorecardV1,
+  type RequirementsV1,
+} from "@apex/contracts";
 import { sha256Json } from "@apex/kernel";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { evaluateQualityScorecard } from "@apex/renderers";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after } from "node:test";
@@ -225,6 +231,43 @@ export function validationEvidence(runId: string, track: "bicep" | "terraform") 
       bytes: 1,
       required: true,
       retention: "immutable",
+    })),
+  };
+}
+
+export async function qualityReport(root: string, runId: string, projectId = "demo") {
+  const scorecard = JSON.parse(
+    await readFile(join(root, ".apex", "runtime", "quality-scorecard.v1.json"), "utf8"),
+  ) as QualityScorecardV1;
+  const measurements = [...scorecard.rules]
+    .map(({ metric, scenario }) => ({ metric, scenario, samples: 0, evidenceRefs: [] as string[] }))
+    .sort((left, right) =>
+      `${left.metric}\u0000${left.scenario}`.localeCompare(`${right.metric}\u0000${right.scenario}`),
+    );
+  const measurementSet = { schemaVersion: CONTRACT_VERSION, measurements };
+  await writeJson(join(root, ".apex", "quality", "measurements.json"), measurementSet);
+  const measurementsHash = sha256Json(measurementSet);
+  const evaluations = evaluateQualityScorecard(scorecard, measurements);
+  return {
+    schemaVersion: CONTRACT_VERSION,
+    projectId,
+    runId,
+    evaluatedAt: "2026-01-01T00:00:00.000Z",
+    scorecardHash: sha256Json(scorecard),
+    measurementsHash,
+    status:
+      evaluations.some(({ decision }) => decision === "fail") ||
+      !evaluations.some(({ decision }) => decision === "pass")
+        ? ("fail" as const)
+        : ("pass" as const),
+    checks: evaluations.map(({ metric, scenario, decision, value, samples, reason }) => ({
+      id: metric,
+      scenario,
+      status: decision,
+      ...(value === undefined ? {} : { value }),
+      samples,
+      evidenceRefs: decision === "omitted" ? [] : [measurementsHash],
+      detail: reason,
     })),
   };
 }

--- a/packages/cli/src/test/quality.test.ts
+++ b/packages/cli/src/test/quality.test.ts
@@ -50,6 +50,11 @@ test("quality evaluate writes deterministic artifacts and quality status reads t
   const first = await readFile(join(root, ".apex", "quality", "evaluation.json"));
   await execute(["quality", "evaluate", "--measurements", measurementsPath, "--scorecard", scorecardPath], root);
   assert.deepEqual(await readFile(join(root, ".apex", "quality", "evaluation.json")), first);
+  const persistedMeasurements = JSON.parse(
+    await readFile(join(root, ".apex", "quality", "measurements.json"), "utf8"),
+  ) as { schemaVersion: string; measurements: Array<{ evidenceRefs: string[] }> };
+  assert.equal(persistedMeasurements.schemaVersion, "1.0.0");
+  assert.deepEqual(persistedMeasurements.measurements[0]?.evidenceRefs, []);
   assert.deepEqual(await execute(["quality", "status"], root), result);
   assert.match(
     await readFile(join(root, ".apex", "quality", "evaluation.md"), "utf8"),
@@ -69,4 +74,17 @@ test("quality evaluate persists and blocks unavailable required measurements", a
   );
   const status = (await execute(["quality", "status"], root)) as { status: string };
   assert.equal(status.status, "fail");
+});
+
+test("quality evaluate does not pass when every claim is omitted", async () => {
+  const root = await tempRoot();
+  const scorecardPath = join(root, "scorecard.json");
+  const measurementsPath = join(root, "measurements.json");
+  await writeJson(scorecardPath, { ...scorecard, rules: [scorecard.rules[1]] });
+  await writeJson(measurementsPath, { measurements: [] });
+  await assert.rejects(
+    execute(["quality", "evaluate", "--measurements", measurementsPath, "--scorecard", scorecardPath], root),
+    /scorecard evaluation failed/i,
+  );
+  assert.equal(((await execute(["quality", "status"], root)) as { status: string }).status, "fail");
 });

--- a/packages/cli/src/workflow-validators.ts
+++ b/packages/cli/src/workflow-validators.ts
@@ -17,12 +17,16 @@ import {
   type ImplementationIntentV1,
   type LogicalResourceManifestV1,
   type PolicyPropertyMapV1,
+  type QualityMeasurementsV1,
+  type QualityReportV1,
+  type QualityScorecardV1,
   type RequirementsV1,
   type ReviewFindingsV1,
   type RunConfigV1,
   type DeploymentPreviewV1,
 } from "@apex/contracts";
 import { WORKFLOW_VALIDATOR_OWNERSHIP, sha256Json, type ValidationIssue, type ValidatorRegistry } from "@apex/kernel";
+import { evaluateQualityScorecard } from "@apex/renderers";
 
 export interface WorkflowTaskValidatorContext {
   readonly nodeId: string;
@@ -31,6 +35,8 @@ export interface WorkflowTaskValidatorContext {
   readonly outputs: Readonly<Record<string, unknown>>;
   readonly artifacts: Readonly<Record<string, unknown>>;
   readonly artifactHashes: Readonly<Record<string, string>>;
+  readonly scorecard?: QualityScorecardV1;
+  readonly qualityMeasurements?: QualityMeasurementsV1;
 }
 
 export interface WorkflowGateValidatorContext {
@@ -466,6 +472,111 @@ function terraformSavedPlanBinding(value: unknown): ValidationIssue[] {
   return valid ? [] : issue("/attestation", "Terraform saved plan is not bound to the exact preview");
 }
 
+function qualityContext(value: unknown): WorkflowTaskValidatorContext & {
+  readonly scorecard: QualityScorecardV1;
+  readonly qualityMeasurements: QualityMeasurementsV1;
+} {
+  return value as WorkflowTaskValidatorContext & {
+    readonly scorecard: QualityScorecardV1;
+    readonly qualityMeasurements: QualityMeasurementsV1;
+  };
+}
+
+function qualityScorecardDecidable(value: unknown): ValidationIssue[] {
+  const context = qualityContext(value);
+  if (context.scorecard === undefined) return issue("/scorecard", "Quality scorecard context is required");
+  if (context.qualityMeasurements === undefined)
+    return issue("/qualityMeasurements", "Quality measurements context is required");
+  const report = context.outputs["quality-report"] as QualityReportV1;
+  const measurementSet = context.qualityMeasurements;
+  const measurements = measurementSet.measurements;
+  const evaluations = evaluateQualityScorecard(context.scorecard, measurements);
+  const checks = new Map(report.checks.map((check) => [`${check.id}\u0000${check.scenario}`, check]));
+  const issues: ValidationIssue[] = [];
+  if (report.scorecardHash !== sha256Json(context.scorecard)) {
+    issues.push({ path: "/outputs/quality-report/scorecardHash", message: "Quality report scorecard hash is stale" });
+  }
+  if (report.measurementsHash !== sha256Json(measurementSet)) {
+    issues.push({ path: "/outputs/quality-report/measurementsHash", message: "Quality measurement hash is invalid" });
+  }
+  if (checks.size !== report.checks.length || checks.size !== context.scorecard.rules.length) {
+    issues.push({
+      path: "/outputs/quality-report/checks",
+      message: "Quality report must contain one check per scorecard rule",
+    });
+  }
+  for (const evaluation of evaluations) {
+    const check = checks.get(`${evaluation.metric}\u0000${evaluation.scenario}`);
+    if (
+      check === undefined ||
+      check.status !== evaluation.decision ||
+      check.samples !== evaluation.samples ||
+      check.value !== evaluation.value ||
+      check.detail !== evaluation.reason
+    ) {
+      issues.push({
+        path: "/outputs/quality-report/checks",
+        message: `Quality decision does not reconcile for ${evaluation.metric}/${evaluation.scenario}`,
+      });
+    }
+  }
+  const expectedStatus =
+    evaluations.some(({ decision }) => decision === "fail") || !evaluations.some(({ decision }) => decision === "pass")
+      ? "fail"
+      : "pass";
+  if (report.status !== expectedStatus) {
+    issues.push({ path: "/outputs/quality-report/status", message: `Quality report status must be ${expectedStatus}` });
+  }
+  return issues;
+}
+
+function qualityNoSubjectiveClaims(value: unknown): ValidationIssue[] {
+  const context = qualityContext(value);
+  if (context.qualityMeasurements === undefined)
+    return issue("/qualityMeasurements", "Quality measurements context is required");
+  const report = context.outputs["quality-report"] as QualityReportV1;
+  const measurements = new Map(
+    context.qualityMeasurements.measurements.map((measurement) => [
+      `${measurement.metric}\u0000${measurement.scenario}`,
+      measurement,
+    ]),
+  );
+  const keys = report.checks.map(({ id, scenario }) => `${id}\u0000${scenario}`);
+  const measurementKeys = context.qualityMeasurements.measurements.map(
+    ({ metric, scenario }) => `${metric}\u0000${scenario}`,
+  );
+  const issues: ValidationIssue[] = [];
+  if (new Set(keys).size !== keys.length) {
+    issues.push({ path: "/outputs/quality-report/checks", message: "Quality checks must be unique" });
+  }
+  if (JSON.stringify(keys) !== JSON.stringify([...keys].sort())) {
+    issues.push({ path: "/outputs/quality-report/checks", message: "Quality checks must use canonical order" });
+  }
+  if (new Set(measurementKeys).size !== measurementKeys.length) {
+    issues.push({ path: "/qualityMeasurements/measurements", message: "Quality measurements must be unique" });
+  }
+  if (JSON.stringify(measurementKeys) !== JSON.stringify([...measurementKeys].sort())) {
+    issues.push({
+      path: "/qualityMeasurements/measurements",
+      message: "Quality measurements must use canonical order",
+    });
+  }
+  for (const check of report.checks) {
+    if (check.value !== undefined && !Number.isFinite(check.value)) {
+      issues.push({ path: "/outputs/quality-report/checks/value", message: "Quality values must be finite" });
+    }
+    const measurement = measurements.get(`${check.id}\u0000${check.scenario}`);
+    const requiredEvidence = new Set([report.measurementsHash, ...(measurement?.evidenceRefs ?? [])]);
+    if (check.status !== "omitted" && [...requiredEvidence].some((hash) => !check.evidenceRefs.includes(hash))) {
+      issues.push({
+        path: "/outputs/quality-report/checks/evidenceRefs",
+        message: `Quality claim ${check.id}/${check.scenario} is missing measurement evidence`,
+      });
+    }
+  }
+  return issues;
+}
+
 export function registerWorkflowValidators(registry: ValidatorRegistry): void {
   registry.register("schema:requirements-v1", RequirementsV1Schema);
   registry.register("schema:architecture-v1", ArchitectureV1Schema);
@@ -510,7 +621,10 @@ export function registerWorkflowValidators(registry: ValidatorRegistry): void {
   registry.registerHandler("preview:freshness", previewFreshness, "freshness");
   registry.registerHandler("terraform:saved-plan-binding", terraformSavedPlanBinding, "authorization");
 
-  const requiredBoundaries = new Set(["task-output", "review", "validation", "gate", "preview"]);
+  registry.registerHandler("quality:scorecard-decidable", qualityScorecardDecidable);
+  registry.registerHandler("quality:no-subjective-deterministic-claims", qualityNoSubjectiveClaims);
+
+  const requiredBoundaries = new Set(["task-output", "review", "validation", "gate", "preview", "quality"]);
   for (const [id, ownership] of WORKFLOW_VALIDATOR_OWNERSHIP) {
     if (requiredBoundaries.has(ownership.boundary) && !registry.has(id)) {
       throw new Error(`Workflow validator ${id} has no registered ${ownership.boundary} handler`);

--- a/packages/contracts/schemas/contract-metadata.json
+++ b/packages/contracts/schemas/contract-metadata.json
@@ -94,6 +94,11 @@
     "maxBytes": 16384,
     "sensitivity": "internal"
   },
+  "https://schemas.apexops.dev/quality-measurements-v1.json": {
+    "compatibility": "strict-v1",
+    "maxBytes": 1048576,
+    "sensitivity": "confidential"
+  },
   "https://schemas.apexops.dev/quality-report-v1.json": {
     "compatibility": "strict-v1",
     "maxBytes": 1048576,

--- a/packages/contracts/schemas/quality-measurements-v1.schema.json
+++ b/packages/contracts/schemas/quality-measurements-v1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$id": "https://schemas.apexops.dev/quality-measurements-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "measurements": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "evidenceRefs": {
+            "items": {
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "metric": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "samples": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "scenario": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "metric",
+          "scenario",
+          "samples",
+          "evidenceRefs"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "schemaVersion": {
+      "const": "1.0.0",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "measurements"
+  ],
+  "type": "object"
+}

--- a/packages/contracts/schemas/quality-report-v1.schema.json
+++ b/packages/contracts/schemas/quality-report-v1.schema.json
@@ -23,10 +23,13 @@
             "minLength": 1,
             "type": "string"
           },
-          "score": {
-            "maximum": 1,
+          "samples": {
             "minimum": 0,
-            "type": "number"
+            "type": "integer"
+          },
+          "scenario": {
+            "minLength": 1,
+            "type": "string"
           },
           "status": {
             "anyOf": [
@@ -39,16 +42,22 @@
                 "type": "string"
               },
               {
-                "const": "unavailable",
+                "const": "omitted",
                 "type": "string"
               }
             ]
+          },
+          "value": {
+            "type": "number"
           }
         },
         "required": [
           "id",
+          "scenario",
           "status",
-          "evidenceRefs"
+          "samples",
+          "evidenceRefs",
+          "detail"
         ],
         "type": "object"
       },
@@ -56,6 +65,10 @@
     },
     "evaluatedAt": {
       "format": "date-time",
+      "type": "string"
+    },
+    "measurementsHash": {
+      "pattern": "^[0-9a-f]{64}$",
       "type": "string"
     },
     "projectId": {
@@ -70,6 +83,10 @@
       "const": "1.0.0",
       "type": "string"
     },
+    "scorecardHash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
     "status": {
       "anyOf": [
         {
@@ -78,10 +95,6 @@
         },
         {
           "const": "fail",
-          "type": "string"
-        },
-        {
-          "const": "incomplete",
           "type": "string"
         }
       ]
@@ -92,6 +105,8 @@
     "projectId",
     "runId",
     "evaluatedAt",
+    "scorecardHash",
+    "measurementsHash",
     "status",
     "checks"
   ],

--- a/packages/contracts/schemas/runtime-bundle-lock-v1.schema.json
+++ b/packages/contracts/schemas/runtime-bundle-lock-v1.schema.json
@@ -15,6 +15,10 @@
       "pattern": "^[0-9a-f]{64}$",
       "type": "string"
     },
+    "qualityScorecardHash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
     "requiredCapabilityPacks": {
       "items": {
         "minLength": 1,
@@ -43,6 +47,7 @@
     "workflowHash",
     "defaultsHash",
     "validatorHash",
+    "qualityScorecardHash",
     "requiredCapabilityPacks"
   ],
   "type": "object"

--- a/packages/contracts/src/evidence.ts
+++ b/packages/contracts/src/evidence.ts
@@ -54,5 +54,25 @@ export const QualityScorecardV1Schema = Type.Object(
   { $id: "https://schemas.apexops.dev/quality-scorecard-v1.json", additionalProperties: false },
 );
 
+export const QualityMeasurementsV1Schema = Type.Object(
+  {
+    schemaVersion: ContractVersionSchema,
+    measurements: Type.Array(
+      Type.Object(
+        {
+          metric: NonEmptyStringSchema,
+          scenario: NonEmptyStringSchema,
+          value: Type.Optional(Type.Number()),
+          samples: Type.Integer({ minimum: 0 }),
+          evidenceRefs: Type.Array(Sha256Schema, { uniqueItems: true }),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+  },
+  { $id: "https://schemas.apexops.dev/quality-measurements-v1.json", additionalProperties: false },
+);
+
 export type EvidenceManifestV1 = Static<typeof EvidenceManifestV1Schema>;
 export type QualityScorecardV1 = Static<typeof QualityScorecardV1Schema>;
+export type QualityMeasurementsV1 = Static<typeof QualityMeasurementsV1Schema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,7 +12,7 @@ import {
   OperationRecordV1Schema,
   ResourceInventoryV1Schema,
 } from "./deployment.js";
-import { EvidenceManifestV1Schema, QualityScorecardV1Schema } from "./evidence.js";
+import { EvidenceManifestV1Schema, QualityMeasurementsV1Schema, QualityScorecardV1Schema } from "./evidence.js";
 import {
   EventV1Schema,
   ProjectConfigV1Schema,
@@ -54,6 +54,7 @@ export const contractSchemas = [
   ResourceInventoryV1Schema,
   EvidenceManifestV1Schema,
   QualityScorecardV1Schema,
+  QualityMeasurementsV1Schema,
   SkuManifestV1Schema,
   ArchitectureV1Schema,
   CostEstimateV1Schema,
@@ -102,6 +103,7 @@ export const contractMetadata: Readonly<Record<string, ContractMetadata>> = {
   "https://schemas.apexops.dev/resource-inventory-v1.json": metadata(4_194_304, "confidential"),
   "https://schemas.apexops.dev/evidence-manifest-v1.json": metadata(524_288, "confidential"),
   "https://schemas.apexops.dev/quality-scorecard-v1.json": metadata(262_144, "public"),
+  "https://schemas.apexops.dev/quality-measurements-v1.json": metadata(1_048_576, "confidential"),
   "https://schemas.apexops.dev/sku-manifest-v1.json": metadata(524_288),
   "https://schemas.apexops.dev/architecture-v1.json": metadata(1_048_576),
   "https://schemas.apexops.dev/cost-estimate-v1.json": metadata(1_048_576, "confidential"),

--- a/packages/contracts/src/runtime.ts
+++ b/packages/contracts/src/runtime.ts
@@ -19,6 +19,7 @@ export const RuntimeBundleLockV1Schema = Type.Object(
     workflowHash: Sha256Schema,
     defaultsHash: Sha256Schema,
     validatorHash: Sha256Schema,
+    qualityScorecardHash: Sha256Schema,
     requiredCapabilityPacks: Type.Array(NonEmptyStringSchema, { uniqueItems: true }),
   },
   { $id: "https://schemas.apexops.dev/runtime-bundle-lock-v1.json", additionalProperties: false },

--- a/packages/contracts/src/targets.ts
+++ b/packages/contracts/src/targets.ts
@@ -364,15 +364,19 @@ export const QualityReportV1Schema = Type.Object(
     projectId: ProjectIdSchema,
     runId: RunIdSchema,
     evaluatedAt: IsoDateTimeSchema,
-    status: Type.Union([Type.Literal("pass"), Type.Literal("fail"), Type.Literal("incomplete")]),
+    scorecardHash: Sha256Schema,
+    measurementsHash: Sha256Schema,
+    status: Type.Union([Type.Literal("pass"), Type.Literal("fail")]),
     checks: Type.Array(
       Type.Object(
         {
           id: NonEmptyStringSchema,
-          status: Type.Union([Type.Literal("pass"), Type.Literal("fail"), Type.Literal("unavailable")]),
-          score: Type.Optional(Type.Number({ minimum: 0, maximum: 1 })),
+          scenario: NonEmptyStringSchema,
+          status: Type.Union([Type.Literal("pass"), Type.Literal("fail"), Type.Literal("omitted")]),
+          value: Type.Optional(Type.Number()),
+          samples: Type.Integer({ minimum: 0 }),
           evidenceRefs: Type.Array(Sha256Schema, { uniqueItems: true }),
-          detail: Type.Optional(NonEmptyStringSchema),
+          detail: NonEmptyStringSchema,
         },
         { additionalProperties: false },
       ),

--- a/packages/contracts/src/test/contracts.test.ts
+++ b/packages/contracts/src/test/contracts.test.ts
@@ -20,6 +20,7 @@ import {
   LogicalResourceManifestV1Schema,
   PolicyPropertyMapV1Schema,
   QualityReportV1Schema,
+  QualityMeasurementsV1Schema,
   RequirementsV1Schema,
   ReviewFindingsV1Schema,
   RuntimeBundleLockV1Schema,
@@ -52,8 +53,8 @@ import {
 
 const hash = "a".repeat(64);
 const otherHash = "b".repeat(64);
-const timestamp = "2026-07-13T12:00:00Z";
-const expiry = "2026-07-13T13:00:00Z";
+const timestamp = "2026-07-13T12:00:00.000Z";
+const expiry = "2026-07-13T13:00:00.000Z";
 
 FormatRegistry.Set("date-time", (value) => Number.isFinite(Date.parse(value)));
 FormatRegistry.Set(
@@ -70,6 +71,7 @@ describe("Wave 1 contracts", () => {
       workflowHash: "a".repeat(64),
       defaultsHash: "b".repeat(64),
       validatorHash: "c".repeat(64),
+      qualityScorecardHash: "d".repeat(64),
       requiredCapabilityPacks: [],
     };
 
@@ -382,8 +384,35 @@ describe("target family contracts", () => {
         projectId: "example-project",
         runId: "run-1",
         evaluatedAt: timestamp,
+        scorecardHash: hash,
+        measurementsHash: hash,
         status: "pass",
-        checks: [{ id: "schema", status: "pass", score: 1, evidenceRefs: [hash] }],
+        checks: [
+          {
+            id: "schema",
+            scenario: "contracts",
+            status: "pass",
+            value: 1,
+            samples: 1,
+            evidenceRefs: [hash],
+            detail: "target satisfied",
+          },
+        ],
+      },
+    ],
+    [
+      QualityMeasurementsV1Schema,
+      {
+        schemaVersion: CONTRACT_VERSION,
+        measurements: [
+          {
+            metric: "schema",
+            scenario: "contracts",
+            value: 1,
+            samples: 1,
+            evidenceRefs: [hash],
+          },
+        ],
       },
     ],
     [

--- a/packages/kernel/src/workflow-validator-ownership.ts
+++ b/packages/kernel/src/workflow-validator-ownership.ts
@@ -164,7 +164,7 @@ const ownershipGroups: readonly OwnershipGroup[] = [
   {
     ids: ["quality:no-subjective-deterministic-claims", "quality:scorecard-decidable"],
     owner: "@apex/cli",
-    entrypoint: "evaluateQuality",
+    entrypoint: "ApexService.validateTaskValidators",
     execution: "inline",
     boundary: "quality",
   },

--- a/packages/testkit/src/fixtures.ts
+++ b/packages/testkit/src/fixtures.ts
@@ -30,6 +30,7 @@ export function runtimeLockFixture(overrides: Partial<RuntimeBundleLockV1> = {})
     workflowHash: fixtureHash("workflow"),
     defaultsHash: fixtureHash("defaults"),
     validatorHash: fixtureHash("validator"),
+    qualityScorecardHash: fixtureHash("quality-scorecard"),
     requiredCapabilityPacks: ["iac"],
     ...overrides,
   };

--- a/packages/testkit/src/qualification.ts
+++ b/packages/testkit/src/qualification.ts
@@ -1,8 +1,8 @@
 import { CapabilityPackLoader } from "@apex/capabilities";
 import { ApexError, ApexService, type ServiceOptions, type TaskOutput } from "@apex/cli";
-import { CONTRACT_VERSION, type ResourceInventoryV1 } from "@apex/contracts";
+import { CONTRACT_VERSION, type QualityScorecardV1, type ResourceInventoryV1 } from "@apex/contracts";
 import { ContentCache, EventJournal, ObjectStore, benchmarkKernel, contentCacheKey, sha256Json } from "@apex/kernel";
-import { renderResourceInventory } from "@apex/renderers";
+import { evaluateQualityScorecard, renderResourceInventory } from "@apex/renderers";
 import { cp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { FakeClock, SequenceIds } from "./determinism.js";
@@ -182,7 +182,7 @@ async function runTrack(
       await context.service.decideGateNumber(4, "approved", "qualification");
       inventory = (await context.service.deploy(preview.previewHash)).inventory;
       await complete(context.service, "diagnosis", [{ kind: "diagnosis", value: diagnosis(context) }]);
-      await complete(context.service, "quality", [{ kind: "quality-report", value: quality(context) }]);
+      await complete(context.service, "quality", [{ kind: "quality-report", value: await quality(context) }]);
       await context.service.render("preview");
       await context.service.render("approval");
       await context.service.render("inventory");
@@ -601,14 +601,45 @@ function diagnosis(context: TrackContext) {
     causes: [],
   };
 }
-function quality(context: TrackContext) {
+async function quality(context: TrackContext) {
+  const scorecard = JSON.parse(
+    await readFile(join(context.root, ".apex", "runtime", "quality-scorecard.v1.json"), "utf8"),
+  ) as QualityScorecardV1;
+  const measurements = [...scorecard.rules]
+    .map(({ metric, scenario }) => ({ metric, scenario, samples: 0, evidenceRefs: [] as string[] }))
+    .sort((left, right) =>
+      `${left.metric}\u0000${left.scenario}`.localeCompare(`${right.metric}\u0000${right.scenario}`),
+    );
+  const measurementSet = { schemaVersion: CONTRACT_VERSION, measurements };
+  await mkdir(join(context.root, ".apex", "quality"), { recursive: true });
+  await writeFile(
+    join(context.root, ".apex", "quality", "measurements.json"),
+    `${JSON.stringify(measurementSet)}\n`,
+    "utf8",
+  );
+  const measurementsHash = sha256Json(measurementSet);
+  const evaluations = evaluateQualityScorecard(scorecard, measurements);
   return {
     schemaVersion: CONTRACT_VERSION,
     projectId: projectId(context.track),
     runId: context.runId,
     evaluatedAt: context.clock.now().toISOString(),
-    status: "pass",
-    checks: [{ id: "deploy", status: "pass", evidenceRefs: [] }],
+    scorecardHash: sha256Json(scorecard),
+    measurementsHash,
+    status:
+      evaluations.some(({ decision }) => decision === "fail") ||
+      !evaluations.some(({ decision }) => decision === "pass")
+        ? ("fail" as const)
+        : ("pass" as const),
+    checks: evaluations.map(({ metric, scenario, decision, value, samples, reason }) => ({
+      id: metric,
+      scenario,
+      status: decision,
+      ...(value === undefined ? {} : { value }),
+      samples,
+      evidenceRefs: decision === "omitted" ? [] : [measurementsHash],
+      detail: reason,
+    })),
   };
 }
 

--- a/packages/testkit/src/quality.ts
+++ b/packages/testkit/src/quality.ts
@@ -26,6 +26,7 @@ export interface MeasurementProvenance {
 }
 
 export interface QualificationMeasurement extends ScorecardMeasurement {
+  readonly evidenceRefs: readonly string[];
   readonly provenance: MeasurementProvenance;
 }
 
@@ -267,10 +268,11 @@ function addMeasurement(
     scenario,
     ...(value === undefined ? {} : { value }),
     samples,
+    evidenceRefs: [...hashes].sort(),
     provenance: {
       source,
       scenario,
-      inputReportHashes: hashes,
+      inputReportHashes: [...hashes].sort(),
       sampleCount: samples,
       collectedAt: options.clock().toISOString(),
       commandVersions: options.commandVersions,


### PR DESCRIPTION
## Summary
- add a persisted, schema-validated `quality-measurements-v1` artifact as independent scorecard evidence
- make quality reports bind the frozen scorecard, canonical measurements, samples, decisions, and evidence refs
- execute both quality validators in manifest order and reject invented or unsupported claims
- enforce minimum-sample and unavailable-data dispositions, including all-omitted failure
- bind the scorecard into the runtime lock and doctor checks
- remove the unsupported `run-lessons-v1` workflow output

## Validation
- scorecard/measurement drift, duplicate/order, evidence, invented-pass, zero-sample, and all-omitted regressions
- contract schema export/metadata tests
- full `npm run test:vnext`
- `npm run validate:vnext`
- `npm run lint:json`, targeted Prettier and cache-free ESLint
- source and packaged workflow reconciliation audit

Tracks #567
Parent #542