### PR TITLE
feat: require architecture availability evidence

### DIFF
--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -1,5 +1,6 @@
 import {
   ApprovalEvidenceV1Schema,
+  ArchitectureAvailabilityV1Schema,
   ArchitectureV1Schema,
   CONTRACT_VERSION,
   CostEstimateV1Schema,
@@ -26,6 +27,7 @@ import {
   hasValidCostArithmetic,
   hasValidLogicalResourceReferences,
   type ApprovalEvidenceV1,
+  type ArchitectureAvailabilityV1,
   type CostEstimateV1,
   type DeploymentPreviewV1,
   type EnvironmentInputsV1,
@@ -236,6 +238,12 @@ interface WorkflowTaskDescriptor {
   capabilities?: string[];
 }
 
+interface WorkflowValidationExecution {
+  validatorIds: string[];
+  evidenceRefs: Record<string, string>;
+  evidenceModes: Record<string, string>;
+}
+
 const TASKS: readonly WorkflowTaskDescriptor[] = [
   { id: "requirements", role: "requirements", outputs: ["requirements", "sku-manifest"] },
   { id: "requirements-review", role: "reviewer", outputs: ["review-findings"], reviewSubject: "requirements", gate: 1 },
@@ -295,6 +303,7 @@ export class ApexService {
     this.validators.register("approval", ApprovalEvidenceV1Schema);
     this.validators.register("runtime-lock", RuntimeBundleLockV1Schema);
     this.validators.register("quality-measurements", QualityMeasurementsV1Schema);
+    this.validators.register("architecture-availability", ArchitectureAvailabilityV1Schema);
     registerWorkflowValidators(this.validators);
     this.providers = {
       fake: new FakeIaCProvider({ track: "bicep", now: this.clock, nextId: this.idSource }),
@@ -598,7 +607,7 @@ export class ApexService {
       throw new ApexError("APEX_AUTHORIZATION", route.blockers.join("; "), EXIT_CODES.authorization, route.blockers);
     if (route.task === undefined)
       throw new ApexError("APEX_NOT_FOUND", "No task is currently available", EXIT_CODES.notFound);
-    return { status: "task", task: await this.issueTask(run, route.task, this.inputRefs(events)) };
+    return { status: "task", task: await this.issueTask(run, route.task, this.inputRefs(events, route.task)) };
   }
 
   async recordRequirementsInput(value: unknown): Promise<void> {
@@ -813,7 +822,8 @@ export class ApexService {
   ): Promise<{ outputHashes: Partial<Record<ArtifactKind, string>>; summary: string }> {
     const run = await this.currentRun();
     const task = await this.readTask(run, taskId);
-    const head = await this.journal(run).head();
+    const events = await this.journal(run).replay();
+    const head = events.at(-1)?.hash ?? null;
     if (head === null) throw new ApexError("APEX_STALE", "Task journal is empty", EXIT_CODES.stale);
     assertTaskCurrent(task, head, run.ownerEpoch, this.clock);
     if (outputs.length === 0)
@@ -842,8 +852,11 @@ export class ApexService {
         throw new ApexError("APEX_VALIDATION", "Task output exceeds its size limit", EXIT_CODES.validation);
       this.validateOutput(run, output);
     }
-    await this.validateBundle(run, descriptor, outputs);
-    const validatorIds = await this.validateTaskValidators(descriptor, outputs);
+    await this.validateBundle(run, descriptor, outputs, events);
+    const validation = await this.validateTaskValidators(run, task, descriptor, outputs, events);
+    const completionHead = await this.journal(run).head();
+    if (completionHead === null) throw new ApexError("APEX_STALE", "Task journal is empty", EXIT_CODES.stale);
+    assertTaskCurrent(task, completionHead, run.ownerEpoch, this.clock);
     const outputHashes: Partial<Record<ArtifactKind, string>> = {};
     for (const output of outputs) outputHashes[output.kind] = await this.objects.putJson(output.value);
     const reviewBlockers = descriptor.reviewSubject === undefined ? [] : this.openReviewFindings(outputs[0]!.value);
@@ -852,7 +865,11 @@ export class ApexService {
       taskId,
       nodeId: descriptor.id,
       artifactHashes: outputHashes,
-      validatorIds,
+      validatorIds: validation.validatorIds,
+      ...(Object.keys(validation.evidenceRefs).length === 0 ? {} : { validatorEvidenceRefs: validation.evidenceRefs }),
+      ...(Object.keys(validation.evidenceModes).length === 0
+        ? {}
+        : { validatorEvidenceModes: validation.evidenceModes }),
       reviewBlockers,
       ...(descriptor.reviewSubject === undefined
         ? {}
@@ -1531,7 +1548,50 @@ export class ApexService {
     if ((input.value === undefined) === (input.file === undefined))
       throw new ApexError("APEX_USAGE", "Evidence requires exactly one value or file", EXIT_CODES.usage);
     const store = await this.evidenceStore(input.kind, input.contentType);
-    const value = input.file === undefined ? input.value! : await readFile(resolve(input.file));
+    let value: JsonValue | Uint8Array = input.file === undefined ? input.value! : await readFile(resolve(input.file));
+    if (input.kind === "architecture-availability-v1") {
+      if (input.contentType !== "application/json")
+        throw new ApexError(
+          "APEX_VALIDATION",
+          "Architecture availability evidence must use application/json",
+          EXIT_CODES.validation,
+        );
+      let parsed: unknown;
+      try {
+        parsed = value instanceof Uint8Array ? (JSON.parse(Buffer.from(value).toString("utf8")) as unknown) : value;
+      } catch (error) {
+        throw new ApexError(
+          "APEX_VALIDATION",
+          "Architecture availability evidence is not valid JSON",
+          EXIT_CODES.validation,
+          undefined,
+          { cause: error },
+        );
+      }
+      this.assertValid("architecture-availability", parsed);
+      const availability = parsed as ArchitectureAvailabilityV1;
+      if (availability.mode === "native") {
+        throw new ApexError(
+          "APEX_AUTHORIZATION",
+          "Native architecture availability evidence requires an authorized capability adapter",
+          EXIT_CODES.authorization,
+        );
+      }
+      for (const check of Object.values(availability.checks)) {
+        try {
+          await this.objects.getBytes(check.evidenceRef);
+        } catch (error) {
+          throw new ApexError(
+            "APEX_VALIDATION",
+            `Architecture availability source evidence is unavailable: ${check.evidenceRef}`,
+            EXIT_CODES.validation,
+            undefined,
+            { cause: error },
+          );
+        }
+      }
+      value = availability;
+    }
     const accepted = await store.accept({
       kind: input.kind,
       contentType: input.contentType,
@@ -1740,11 +1800,29 @@ export class ApexService {
     return field === undefined ? undefined : this.latestPayloadHash(events, "task.completed", field);
   }
 
-  private inputRefs(events: Awaited<ReturnType<EventJournal["replay"]>>): string[] {
+  private inputRefs(events: Awaited<ReturnType<EventJournal["replay"]>>, descriptor: WorkflowTaskDescriptor): string[] {
+    const availabilityKinds = new Set([
+      "architecture-availability-v1",
+      "pricing-evidence",
+      "quota-evidence",
+      "regionalAvailability-evidence",
+      "regional-availability-evidence",
+    ]);
     const hashes = events.flatMap((event) => {
-      if (event.type !== "task.completed") return [];
-      const artifactHashes = (event.payload as { artifactHashes?: Record<string, unknown> }).artifactHashes ?? {};
-      return Object.values(artifactHashes).filter((hash): hash is string => typeof hash === "string");
+      if (event.type === "task.completed") {
+        const artifactHashes = (event.payload as { artifactHashes?: Record<string, unknown> }).artifactHashes ?? {};
+        return Object.values(artifactHashes).filter((hash): hash is string => typeof hash === "string");
+      }
+      if (event.type === "evidence.accepted" && descriptor.id === "architecture") {
+        const payload = event.payload as { hash?: unknown; kind?: unknown; status?: unknown };
+        return typeof payload.hash === "string" &&
+          typeof payload.kind === "string" &&
+          payload.status === "accepted" &&
+          availabilityKinds.has(payload.kind)
+          ? [payload.hash]
+          : [];
+      }
+      return [];
     });
     return [...new Set(hashes)];
   }
@@ -2018,11 +2096,11 @@ export class ApexService {
     run: RunConfigV1,
     descriptor: WorkflowTaskDescriptor,
     outputs: TaskOutput[],
+    events: Awaited<ReturnType<EventJournal["replay"]>>,
   ): Promise<void> {
     const byKind = Object.fromEntries(outputs.map((output) => [output.kind, output.value])) as Partial<
       Record<ArtifactKind, unknown>
     >;
-    const events = await this.journal(run).replay();
     if (descriptor.id === "plan") {
       const intent = byKind["implementation-intent"] as ImplementationIntentV1;
       const binding = byKind["iac-binding"] as IacBindingV1;
@@ -2098,7 +2176,13 @@ export class ApexService {
     }
   }
 
-  private async validateTaskValidators(descriptor: WorkflowTaskDescriptor, outputs: TaskOutput[]): Promise<string[]> {
+  private async validateTaskValidators(
+    run: RunConfigV1,
+    task: TaskEnvelopeV1,
+    descriptor: WorkflowTaskDescriptor,
+    outputs: TaskOutput[],
+    events: Awaited<ReturnType<EventJournal["replay"]>>,
+  ): Promise<WorkflowValidationExecution> {
     const workflow = new WorkflowEngine(
       JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
     );
@@ -2113,9 +2197,11 @@ export class ApexService {
           : descriptor.id === "quality"
             ? "quality"
             : "task-output";
-    const validatorIds = node.validators.filter((id) => workflowValidatorOwnership(id)?.boundary === boundary);
-    const run = await this.currentRun();
-    const events = await this.journal(run).replay();
+    const boundaries = new Set([boundary, ...(descriptor.id === "architecture" ? ["external-evidence"] : [])]);
+    const validatorIds = node.validators.filter((id) => {
+      const validatorBoundary = workflowValidatorOwnership(id)?.boundary;
+      return validatorBoundary !== undefined && boundaries.has(validatorBoundary);
+    });
     const artifactHashes: Record<string, string> = {};
     for (const event of events) {
       if (event.type !== "task.completed") continue;
@@ -2127,19 +2213,46 @@ export class ApexService {
         Object.entries(artifactHashes).map(async ([kind, hash]) => [kind, await this.objects.getJson<unknown>(hash)]),
       ),
     );
+    let availabilityEvidence: ArchitectureAvailabilityV1 | undefined;
+    let availabilityHash: string | undefined;
+    if (descriptor.id === "architecture") {
+      const pinnedRefs = new Set(task.inputRefs);
+      availabilityHash = this.latestPayloadHash(
+        events,
+        "evidence.accepted",
+        "hash",
+        (payload) =>
+          payload.kind === "architecture-availability-v1" &&
+          payload.status === "accepted" &&
+          typeof payload.hash === "string" &&
+          pinnedRefs.has(payload.hash),
+      );
+      if (availabilityHash !== undefined) {
+        availabilityEvidence = await this.objects.getJson<ArchitectureAvailabilityV1>(availabilityHash);
+        this.assertValid("architecture-availability", availabilityEvidence);
+      }
+    }
     const context: WorkflowTaskValidatorContext = {
       nodeId,
       now: this.clock().toISOString(),
       track: run.iacTool,
+      targetScope: run.targetScope,
+      inputRefs: task.inputRefs,
       outputs: Object.fromEntries(outputs.map(({ kind, value }) => [kind, value])),
       artifacts,
       artifactHashes,
+      ...(availabilityEvidence === undefined ? {} : { availabilityEvidence }),
       ...(nodeId === "quality" ? await this.qualityValidatorContext() : {}),
     };
     for (const id of validatorIds) {
       this.assertValid(id, taskWorkflowValidatorInput(id, context));
     }
-    return validatorIds;
+    return {
+      validatorIds,
+      evidenceRefs: availabilityHash === undefined ? {} : { "business:availability-current": availabilityHash },
+      evidenceModes:
+        availabilityEvidence === undefined ? {} : { "business:availability-current": availabilityEvidence.mode },
+    };
   }
 
   private async qualityValidatorContext(): Promise<{

--- a/packages/cli/src/test/expanded-workflow.test.ts
+++ b/packages/cli/src/test/expanded-workflow.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -18,6 +18,8 @@ import { createMcpServer } from "../mcp.js";
 import { ApexService, type TaskOutput } from "../service.js";
 import {
   architecture,
+  acceptAvailabilityEvidence,
+  availabilityEvidence,
   codegenBundle,
   costEstimate,
   governance,
@@ -64,6 +66,7 @@ async function reachCodegen(
     { kind: "review-findings", value: review(runId, "requirements", requirementHashes.requirements!) },
   ]);
   await service.decideGateNumber(1, "approved", "tester");
+  await acceptAvailabilityEvidence(service, runId);
 
   const architectureValues: TaskOutput[] = [
     { kind: "architecture", value: architecture(runId) },
@@ -293,6 +296,7 @@ test("task-bound workflow validators reject semantic and evidence mutations", as
     },
   ]);
   await service.decideGateNumber(1, "approved", "tester");
+  const availabilityHash = await acceptAvailabilityEvidence(service, runId);
 
   const architectureTask = await task(service, "architecture");
   const untraceableArchitecture = architecture(runId);
@@ -318,7 +322,14 @@ test("task-bound workflow validators reject semantic and evidence mutations", as
     "schema:architecture-v1",
     "business:requirements-traceability",
     "business:cost-arithmetic",
+    "business:availability-current",
   ]);
+  assert.deepEqual((architectureCompleted?.payload as { validatorEvidenceRefs?: unknown }).validatorEvidenceRefs, {
+    "business:availability-current": availabilityHash,
+  });
+  assert.deepEqual((architectureCompleted?.payload as { validatorEvidenceModes?: unknown }).validatorEvidenceModes, {
+    "business:availability-current": "simulated",
+  });
   await complete(service, "architecture-review", [
     {
       kind: "review-findings",
@@ -419,6 +430,113 @@ test("task-bound workflow validators reject semantic and evidence mutations", as
     /bicep:format/,
   );
   await service.completeTaskOutputs(validationTask, [{ kind: "validation-evidence", value: validEvidence }]);
+});
+
+test("architecture requires current scope-bound availability evidence", async () => {
+  const root = await tempRoot();
+  const service = new ApexService(root);
+  const { runId } = await service.init({ projectId: "demo" });
+  await service.nextTask();
+  const requirementHashes = await complete(service, "requirements", [
+    { kind: "requirements", value: requirements() },
+    { kind: "sku-manifest", value: skuManifest(sha256Json(requirements())) },
+  ]);
+  await complete(service, "requirements-review", [
+    {
+      kind: "review-findings",
+      value: review(runId, "requirements", requirementHashes.requirements!),
+    },
+  ]);
+  await service.decideGateNumber(1, "approved", "tester");
+
+  const malformedPath = join(root, "invalid-availability.json");
+  await writeFile(malformedPath, "{", "utf8");
+  await assert.rejects(
+    service.acceptEvidence({
+      kind: "architecture-availability-v1",
+      contentType: "application/json",
+      file: malformedPath,
+      required: true,
+    }),
+    /not valid JSON/,
+  );
+
+  await assert.rejects(
+    service.acceptEvidence({
+      kind: "architecture-availability-v1",
+      contentType: "application/json",
+      value: availabilityEvidence(runId),
+      required: true,
+    }),
+    /source evidence is unavailable/,
+  );
+  const architectureOutputs: TaskOutput[] = [
+    { kind: "architecture", value: architecture(runId) },
+    { kind: "cost-estimate", value: costEstimate(runId) },
+  ];
+  await assert.rejects(
+    service.completeTaskOutputs(await task(service, "architecture"), architectureOutputs),
+    /business:availability-current/,
+  );
+
+  const staleHash = await acceptAvailabilityEvidence(service, runId, "demo", "local", {
+    expiresAt: "2020-01-01T00:00:00.000Z",
+  });
+  const staleTask = await service.nextTask();
+  assert.equal(staleTask.status, "task");
+  if (staleTask.status !== "task") return;
+  assert.ok(staleTask.task.inputRefs.includes(staleHash));
+  await assert.rejects(
+    service.completeTaskOutputs(staleTask.task.taskId, architectureOutputs),
+    /business:availability-current/,
+  );
+
+  await acceptAvailabilityEvidence(service, runId, "demo", "local", {
+    collectedAt: "2099-01-01T00:00:00.000Z",
+  });
+  await assert.rejects(
+    service.completeTaskOutputs(await task(service, "architecture"), architectureOutputs),
+    (error: unknown) =>
+      error instanceof ApexError && JSON.stringify(error.details).includes("future collection timestamp"),
+  );
+
+  await acceptAvailabilityEvidence(service, runId, "demo", "local", {
+    evidenceTargetScope: "other-scope",
+  });
+  await assert.rejects(
+    service.completeTaskOutputs(await task(service, "architecture"), architectureOutputs),
+    /business:availability-current/,
+  );
+
+  await assert.rejects(
+    acceptAvailabilityEvidence(service, runId, "demo", "local", { mode: "native" }),
+    /authorized capability adapter/,
+  );
+
+  await acceptAvailabilityEvidence(service, runId, "demo", "local", { unavailableCheck: "quota" });
+  await assert.rejects(
+    service.completeTaskOutputs(await task(service, "architecture"), architectureOutputs),
+    /business:availability-current/,
+  );
+
+  const currentHash = await acceptAvailabilityEvidence(service, runId);
+  const currentTask = await service.nextTask();
+  assert.equal(currentTask.status, "task");
+  if (currentTask.status !== "task") return;
+  assert.ok(currentTask.task.inputRefs.includes(currentHash));
+  await acceptAvailabilityEvidence(service, runId, "demo", "local", {
+    expiresAt: "2020-01-01T00:00:00.000Z",
+  });
+  await assert.rejects(
+    service.completeTaskOutputs(currentTask.task.taskId, architectureOutputs),
+    (error: unknown) => error instanceof Error && /stale/i.test(error.message),
+  );
+  const replacementHash = await acceptAvailabilityEvidence(service, runId);
+  const replacementTask = await service.nextTask();
+  assert.equal(replacementTask.status, "task");
+  if (replacementTask.status !== "task") return;
+  assert.ok(replacementTask.task.inputRefs.includes(replacementHash));
+  await service.completeTaskOutputs(replacementTask.task.taskId, architectureOutputs);
 });
 
 for (const track of ["bicep", "terraform"] as const) {

--- a/packages/cli/src/test/helpers.ts
+++ b/packages/cli/src/test/helpers.ts
@@ -130,6 +130,88 @@ export function governance(runId: string) {
   };
 }
 
+export function availabilityEvidence(
+  runId: string,
+  projectId = "demo",
+  targetScope = "local",
+  mode: "native" | "simulated" = "simulated",
+  evidenceRefs = {
+    pricing: "1".repeat(64),
+    quota: "2".repeat(64),
+    regionalAvailability: "3".repeat(64),
+  },
+  expiresAt = "2099-01-01T00:00:00.000Z",
+  unavailableCheck?: "pricing" | "quota" | "regionalAvailability",
+  collectedAt = "2026-01-01T00:00:00.000Z",
+) {
+  return {
+    schemaVersion: CONTRACT_VERSION,
+    projectId,
+    runId,
+    targetScope,
+    mode,
+    collectedAt,
+    expiresAt,
+    checks: {
+      pricing: {
+        status: unavailableCheck === "pricing" ? ("unavailable" as const) : ("current" as const),
+        evidenceRef: evidenceRefs.pricing,
+      },
+      quota: {
+        status: unavailableCheck === "quota" ? ("unavailable" as const) : ("current" as const),
+        evidenceRef: evidenceRefs.quota,
+      },
+      regionalAvailability: {
+        status: unavailableCheck === "regionalAvailability" ? ("unavailable" as const) : ("current" as const),
+        evidenceRef: evidenceRefs.regionalAvailability,
+      },
+    },
+  };
+}
+
+export async function acceptAvailabilityEvidence(
+  service: ApexService,
+  runId: string,
+  projectId = "demo",
+  targetScope = "local",
+  options: {
+    evidenceTargetScope?: string;
+    expiresAt?: string;
+    unavailableCheck?: "pricing" | "quota" | "regionalAvailability";
+    collectedAt?: string;
+    mode?: "native" | "simulated";
+  } = {},
+): Promise<string> {
+  const refs = { pricing: "", quota: "", regionalAvailability: "" };
+  for (const source of ["pricing", "quota", "regionalAvailability"] as const) {
+    const accepted = (await service.acceptEvidence({
+      kind: `${source}-evidence`,
+      contentType: "application/json",
+      value: { source, mode: "simulated", status: "current" },
+      required: true,
+    })) as { hash?: string };
+    if (accepted.hash === undefined) throw new Error(`${source} evidence was not accepted`);
+    refs[source] = accepted.hash;
+  }
+  const accepted = (await service.acceptEvidence({
+    kind: "architecture-availability-v1",
+    contentType: "application/json",
+    value: availabilityEvidence(
+      runId,
+      projectId,
+      options.evidenceTargetScope ?? targetScope,
+      options.mode ?? "simulated",
+      refs,
+      options.expiresAt,
+      options.unavailableCheck,
+      options.collectedAt,
+    ),
+    required: true,
+  })) as { hash?: string };
+  if (accepted.hash === undefined) throw new Error("Availability evidence was not accepted");
+  return accepted.hash;
+}
+
 export function policyMap(runId: string, governanceHash: string) {
   return { schemaVersion: CONTRACT_VERSION, projectId: "demo", runId, governanceHash, mappings: [] };
 }
@@ -289,6 +371,7 @@ export async function prepareValidatedRun(service: ApexService, runId: string, t
     { kind: "review-findings", value: review(runId, "requirements", requirementHashes.outputHashes.requirements!) },
   ]);
   await service.decideGateNumber(1, "approved", "tester");
+  await acceptAvailabilityEvidence(service, runId);
   const architectureHashes = await complete("architecture", [
     { kind: "architecture", value: architecture(runId) },
     { kind: "cost-estimate", value: costEstimate(runId) },

--- a/packages/cli/src/workflow-validators.ts
+++ b/packages/cli/src/workflow-validators.ts
@@ -7,6 +7,7 @@ import {
   RequirementsV1Schema,
   hasValidCostArithmetic,
   type ApprovalEvidenceV1,
+  type ArchitectureAvailabilityV1,
   type ArchitectureV1,
   type CostEstimateV1,
   type EvidenceManifestV1,
@@ -32,11 +33,14 @@ export interface WorkflowTaskValidatorContext {
   readonly nodeId: string;
   readonly now: string;
   readonly track: "bicep" | "terraform";
+  readonly targetScope: string;
+  readonly inputRefs: readonly string[];
   readonly outputs: Readonly<Record<string, unknown>>;
   readonly artifacts: Readonly<Record<string, unknown>>;
   readonly artifactHashes: Readonly<Record<string, string>>;
   readonly scorecard?: QualityScorecardV1;
   readonly qualityMeasurements?: QualityMeasurementsV1;
+  readonly availabilityEvidence?: ArchitectureAvailabilityV1;
 }
 
 export interface WorkflowGateValidatorContext {
@@ -119,6 +123,56 @@ function requirementsTraceability(value: unknown): ValidationIssue[] {
 function costArithmetic(value: unknown): ValidationIssue[] {
   const estimate = taskContext(value).outputs["cost-estimate"] as CostEstimateV1;
   return hasValidCostArithmetic(estimate) ? [] : issue("/outputs/cost-estimate", "Cost arithmetic does not reconcile");
+}
+
+function availabilityCurrent(value: unknown): ValidationIssue[] {
+  const context = taskContext(value);
+  const evidence = context.availabilityEvidence;
+  if (evidence === undefined)
+    return issue("/availabilityEvidence", "Current architecture availability evidence is required");
+  const architecture = context.outputs.architecture as ArchitectureV1;
+  const issues: ValidationIssue[] = [];
+  if (
+    evidence.projectId !== architecture.projectId ||
+    evidence.runId !== architecture.runId ||
+    evidence.targetScope !== context.targetScope
+  ) {
+    issues.push({
+      path: "/availabilityEvidence",
+      message: "Availability evidence does not match the architecture run",
+    });
+  }
+  const missingSourceRefs = Object.values(evidence.checks)
+    .map(({ evidenceRef }) => evidenceRef)
+    .filter((reference) => !context.inputRefs.includes(reference))
+    .sort();
+  if (missingSourceRefs.length > 0) {
+    issues.push({
+      path: "/availabilityEvidence/checks",
+      message: `Availability source evidence was not pinned to the task: ${missingSourceRefs.join(", ")}`,
+    });
+  }
+  const now = Date.parse(context.now);
+  if (Date.parse(evidence.collectedAt) > now) {
+    issues.push({
+      path: "/availabilityEvidence/collectedAt",
+      message: "Architecture availability evidence has a future collection timestamp",
+    });
+  }
+  if (Date.parse(evidence.expiresAt) <= now) {
+    issues.push({ path: "/availabilityEvidence/expiresAt", message: "Architecture availability evidence is expired" });
+  }
+  const unavailable = Object.entries(evidence.checks)
+    .filter(([, check]) => check.status !== "current")
+    .map(([name]) => name)
+    .sort();
+  if (unavailable.length > 0) {
+    issues.push({
+      path: "/availabilityEvidence/checks",
+      message: `Architecture availability checks are not current: ${unavailable.join(", ")}`,
+    });
+  }
+  return issues;
 }
 
 function governanceCompleteness(value: unknown): ValidationIssue[] {
@@ -588,6 +642,7 @@ export function registerWorkflowValidators(registry: ValidatorRegistry): void {
   registry.registerHandler("business:requirements-completeness", requirementsCompleteness);
   registry.registerHandler("business:requirements-traceability", requirementsTraceability);
   registry.registerHandler("business:cost-arithmetic", costArithmetic);
+  registry.registerHandler("business:availability-current", availabilityCurrent, "freshness");
   registry.registerHandler("business:governance-completeness", governanceCompleteness);
   registry.registerHandler("business:governance-freshness", governanceFreshness, "freshness");
   registry.registerHandler("business:policy-effect-coverage", policyEffectCoverage);
@@ -624,7 +679,15 @@ export function registerWorkflowValidators(registry: ValidatorRegistry): void {
   registry.registerHandler("quality:scorecard-decidable", qualityScorecardDecidable);
   registry.registerHandler("quality:no-subjective-deterministic-claims", qualityNoSubjectiveClaims);
 
-  const requiredBoundaries = new Set(["task-output", "review", "validation", "gate", "preview", "quality"]);
+  const requiredBoundaries = new Set([
+    "task-output",
+    "review",
+    "external-evidence",
+    "validation",
+    "gate",
+    "preview",
+    "quality",
+  ]);
   for (const [id, ownership] of WORKFLOW_VALIDATOR_OWNERSHIP) {
     if (requiredBoundaries.has(ownership.boundary) && !registry.has(id)) {
       throw new Error(`Workflow validator ${id} has no registered ${ownership.boundary} handler`);

--- a/packages/contracts/schemas/architecture-availability-v1.schema.json
+++ b/packages/contracts/schemas/architecture-availability-v1.schema.json
@@ -1,0 +1,155 @@
+{
+  "$id": "https://schemas.apexops.dev/architecture-availability-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "checks": {
+      "additionalProperties": false,
+      "properties": {
+        "pricing": {
+          "additionalProperties": false,
+          "properties": {
+            "evidenceRef": {
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "status": {
+              "anyOf": [
+                {
+                  "const": "current",
+                  "type": "string"
+                },
+                {
+                  "const": "unavailable",
+                  "type": "string"
+                },
+                {
+                  "const": "blocked",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": [
+            "status",
+            "evidenceRef"
+          ],
+          "type": "object"
+        },
+        "quota": {
+          "additionalProperties": false,
+          "properties": {
+            "evidenceRef": {
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "status": {
+              "anyOf": [
+                {
+                  "const": "current",
+                  "type": "string"
+                },
+                {
+                  "const": "unavailable",
+                  "type": "string"
+                },
+                {
+                  "const": "blocked",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": [
+            "status",
+            "evidenceRef"
+          ],
+          "type": "object"
+        },
+        "regionalAvailability": {
+          "additionalProperties": false,
+          "properties": {
+            "evidenceRef": {
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "status": {
+              "anyOf": [
+                {
+                  "const": "current",
+                  "type": "string"
+                },
+                {
+                  "const": "unavailable",
+                  "type": "string"
+                },
+                {
+                  "const": "blocked",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": [
+            "status",
+            "evidenceRef"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "pricing",
+        "quota",
+        "regionalAvailability"
+      ],
+      "type": "object"
+    },
+    "collectedAt": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "expiresAt": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "mode": {
+      "anyOf": [
+        {
+          "const": "native",
+          "type": "string"
+        },
+        {
+          "const": "simulated",
+          "type": "string"
+        }
+      ]
+    },
+    "projectId": {
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "type": "string"
+    },
+    "runId": {
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$",
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": "1.0.0",
+      "type": "string"
+    },
+    "targetScope": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "projectId",
+    "runId",
+    "targetScope",
+    "mode",
+    "collectedAt",
+    "expiresAt",
+    "checks"
+  ],
+  "type": "object"
+}

--- a/packages/contracts/schemas/contract-metadata.json
+++ b/packages/contracts/schemas/contract-metadata.json
@@ -4,6 +4,11 @@
     "maxBytes": 32768,
     "sensitivity": "confidential"
   },
+  "https://schemas.apexops.dev/architecture-availability-v1.json": {
+    "compatibility": "strict-v1",
+    "maxBytes": 131072,
+    "sensitivity": "confidential"
+  },
   "https://schemas.apexops.dev/architecture-v1.json": {
     "compatibility": "strict-v1",
     "maxBytes": 1048576,

--- a/packages/contracts/src/evidence.ts
+++ b/packages/contracts/src/evidence.ts
@@ -73,6 +73,36 @@ export const QualityMeasurementsV1Schema = Type.Object(
   { $id: "https://schemas.apexops.dev/quality-measurements-v1.json", additionalProperties: false },
 );
 
+const AvailabilityCheckV1Schema = Type.Object(
+  {
+    status: Type.Union([Type.Literal("current"), Type.Literal("unavailable"), Type.Literal("blocked")]),
+    evidenceRef: Sha256Schema,
+  },
+  { additionalProperties: false },
+);
+
+export const ArchitectureAvailabilityV1Schema = Type.Object(
+  {
+    schemaVersion: ContractVersionSchema,
+    projectId: ProjectIdSchema,
+    runId: RunIdSchema,
+    targetScope: NonEmptyStringSchema,
+    mode: Type.Union([Type.Literal("native"), Type.Literal("simulated")]),
+    collectedAt: IsoDateTimeSchema,
+    expiresAt: IsoDateTimeSchema,
+    checks: Type.Object(
+      {
+        pricing: AvailabilityCheckV1Schema,
+        quota: AvailabilityCheckV1Schema,
+        regionalAvailability: AvailabilityCheckV1Schema,
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { $id: "https://schemas.apexops.dev/architecture-availability-v1.json", additionalProperties: false },
+);
+
 export type EvidenceManifestV1 = Static<typeof EvidenceManifestV1Schema>;
 export type QualityScorecardV1 = Static<typeof QualityScorecardV1Schema>;
 export type QualityMeasurementsV1 = Static<typeof QualityMeasurementsV1Schema>;
+export type ArchitectureAvailabilityV1 = Static<typeof ArchitectureAvailabilityV1Schema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,7 +12,12 @@ import {
   OperationRecordV1Schema,
   ResourceInventoryV1Schema,
 } from "./deployment.js";
-import { EvidenceManifestV1Schema, QualityMeasurementsV1Schema, QualityScorecardV1Schema } from "./evidence.js";
+import {
+  ArchitectureAvailabilityV1Schema,
+  EvidenceManifestV1Schema,
+  QualityMeasurementsV1Schema,
+  QualityScorecardV1Schema,
+} from "./evidence.js";
 import {
   EventV1Schema,
   ProjectConfigV1Schema,
@@ -55,6 +60,7 @@ export const contractSchemas = [
   EvidenceManifestV1Schema,
   QualityScorecardV1Schema,
   QualityMeasurementsV1Schema,
+  ArchitectureAvailabilityV1Schema,
   SkuManifestV1Schema,
   ArchitectureV1Schema,
   CostEstimateV1Schema,
@@ -104,6 +110,7 @@ export const contractMetadata: Readonly<Record<string, ContractMetadata>> = {
   "https://schemas.apexops.dev/evidence-manifest-v1.json": metadata(524_288, "confidential"),
   "https://schemas.apexops.dev/quality-scorecard-v1.json": metadata(262_144, "public"),
   "https://schemas.apexops.dev/quality-measurements-v1.json": metadata(1_048_576, "confidential"),
+  "https://schemas.apexops.dev/architecture-availability-v1.json": metadata(131_072, "confidential"),
   "https://schemas.apexops.dev/sku-manifest-v1.json": metadata(524_288),
   "https://schemas.apexops.dev/architecture-v1.json": metadata(1_048_576),
   "https://schemas.apexops.dev/cost-estimate-v1.json": metadata(1_048_576, "confidential"),

--- a/packages/contracts/src/test/contracts.test.ts
+++ b/packages/contracts/src/test/contracts.test.ts
@@ -21,6 +21,7 @@ import {
   PolicyPropertyMapV1Schema,
   QualityReportV1Schema,
   QualityMeasurementsV1Schema,
+  ArchitectureAvailabilityV1Schema,
   RequirementsV1Schema,
   ReviewFindingsV1Schema,
   RuntimeBundleLockV1Schema,
@@ -413,6 +414,23 @@ describe("target family contracts", () => {
             evidenceRefs: [hash],
           },
         ],
+      },
+    ],
+    [
+      ArchitectureAvailabilityV1Schema,
+      {
+        schemaVersion: CONTRACT_VERSION,
+        projectId: "example-project",
+        runId: "run-1",
+        targetScope: "local",
+        mode: "simulated",
+        collectedAt: timestamp,
+        expiresAt: expiry,
+        checks: {
+          pricing: { status: "current", evidenceRef: hash },
+          quota: { status: "current", evidenceRef: hash },
+          regionalAvailability: { status: "current", evidenceRef: hash },
+        },
       },
     ],
     [

--- a/packages/kernel/src/workflow-validator-ownership.ts
+++ b/packages/kernel/src/workflow-validator-ownership.ts
@@ -61,7 +61,7 @@ const ownershipGroups: readonly OwnershipGroup[] = [
   {
     ids: ["business:availability-current"],
     owner: "@apex/cli",
-    entrypoint: "ApexService.completeTask",
+    entrypoint: "ApexService.validateTaskValidators",
     execution: "capability",
     boundary: "external-evidence",
   },

--- a/packages/testkit/src/qualification.ts
+++ b/packages/testkit/src/qualification.ts
@@ -347,6 +347,23 @@ async function completeCreativeWorkflow(context: TrackContext): Promise<void> {
     { kind: "review-findings", value: review(context, "requirements", requirementHashes.requirements!) },
   ]);
   await service.decideGateNumber(1, "approved", "qualification");
+  const availabilityRefs: Record<string, string> = {};
+  for (const source of ["pricing", "quota", "regionalAvailability"] as const) {
+    const accepted = (await service.acceptEvidence({
+      kind: `${source}-evidence`,
+      contentType: "application/json",
+      value: { source, mode: "simulated", status: "current" },
+      required: true,
+    })) as { hash?: string };
+    if (accepted.hash === undefined) throw new Error(`${source} evidence was not accepted`);
+    availabilityRefs[source] = accepted.hash;
+  }
+  await service.acceptEvidence({
+    kind: "architecture-availability-v1",
+    contentType: "application/json",
+    value: availabilityEvidence(context, availabilityRefs),
+    required: true,
+  });
   restart(context);
   const architectureHashes = await complete(context.service, "architecture", [
     { kind: "architecture", value: architecture(context) },
@@ -498,6 +515,25 @@ function governance(context: TrackContext) {
     expiresAt: "2027-01-01T00:00:00.000Z",
     summary: { assignmentCount: 0, denyCount: 0, modifyCount: 0, auditCount: 0, exemptionCount: 0 },
     constraintsRef: { mediaType: "application/json", uri: "memory://constraints", digest: HASH, bytes: 0 },
+  };
+}
+function availabilityEvidence(context: TrackContext, evidenceRefs: Record<string, string>) {
+  return {
+    schemaVersion: CONTRACT_VERSION,
+    projectId: projectId(context.track),
+    runId: context.runId,
+    targetScope: "local",
+    mode: "simulated" as const,
+    collectedAt: context.clock.now().toISOString(),
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    checks: {
+      pricing: { status: "current" as const, evidenceRef: evidenceRefs.pricing! },
+      quota: { status: "current" as const, evidenceRef: evidenceRefs.quota! },
+      regionalAvailability: {
+        status: "current" as const,
+        evidenceRef: evidenceRefs.regionalAvailability!,
+      },
+    },
   };
 }
 function policyMap(context: TrackContext, governanceHash: string) {


### PR DESCRIPTION
## Summary
- add strict `architecture-availability-v1` pricing, quota, and region evidence
- require source evidence objects to resolve in the immutable store
- pin availability and its sources into the issued architecture task
- execute `business:availability-current` as a non-cached freshness validator in manifest order
- journal the exact combined evidence hash and explicit simulated mode
- reserve native mode for a future authorized capability adapter

## Validation
- malformed, missing-source, future, expired, wrong-scope, unavailable, forged-native, and post-issuance churn regressions
- full `npm run test:vnext`
- `npm run validate:vnext`
- contracts/schema metadata, JSON, formatting, lint, and hooks
- independent ownership and schema audit

Tracks #569
Parent #542