### PR TITLE
feat: enforce workflow deploy validators

### DIFF
--- a/packages/capabilities/src/iac.ts
+++ b/packages/capabilities/src/iac.ts
@@ -10,6 +10,7 @@ import type {
 
 export type IacProviderErrorCode =
   | "APPROVAL_EXPIRED"
+  | "APPROVAL_DEPENDENCY_HASH_MISMATCH"
   | "APPROVAL_HASH_MISMATCH"
   | "APPROVAL_RECIPIENT_MISMATCH"
   | "APPROVAL_REJECTED"
@@ -63,6 +64,13 @@ export interface CurrentDeploymentAuthority {
   readonly recipientIdentity: string;
 }
 
+export interface ProviderExecutionEvidence {
+  readonly mode: "native";
+  readonly operationId: string;
+  readonly previewHash: string;
+  readonly validatorIds: readonly string[];
+}
+
 export interface PreviewAuthorizationContext {
   readonly operation: Operation;
   readonly track: IacTool;
@@ -106,8 +114,14 @@ export function authorizeDeploymentPreview(context: PreviewAuthorizationContext)
   if (approval.decision !== "approved") {
     throw new IacProviderError("APPROVAL_REJECTED", "Deployment approval was not granted");
   }
-  if (approval.previewHash !== preview.previewHash || approval.dependencyHash !== preview.previewHash) {
+  if (approval.previewHash !== preview.previewHash) {
     throw new IacProviderError("APPROVAL_HASH_MISMATCH", "Approval is not bound to this exact preview");
+  }
+  if (approval.dependencyHash !== preview.previewHash) {
+    throw new IacProviderError(
+      "APPROVAL_DEPENDENCY_HASH_MISMATCH",
+      "Approval gate dependency hash is not bound to this preview",
+    );
   }
   if (approval.writerEpoch !== authority.ownerEpoch) {
     throw new IacProviderError("APPROVAL_WRITER_EPOCH_MISMATCH", "Approval writer epoch is stale");
@@ -137,6 +151,7 @@ export interface IacProvider {
   ): Promise<OperationRecordV1>;
   inventory(projectId: string, runId: string): Promise<ResourceInventoryV1>;
   reconcile(operationId: string): Promise<OperationRecordV1 | undefined>;
+  executionEvidence?(operationId: string): ProviderExecutionEvidence | undefined;
 }
 
 export interface FakeIaCProviderOptions {
@@ -150,9 +165,10 @@ function canonical(value: unknown): string {
     return `[${value.map(canonical).join(",")}]`;
   }
   if (value !== null && typeof value === "object") {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${canonical(entry)}`)
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`)
       .join(",")}}`;
   }
   return JSON.stringify(value);

--- a/packages/capabilities/src/native-iac-providers.ts
+++ b/packages/capabilities/src/native-iac-providers.ts
@@ -21,6 +21,7 @@ import {
   sha256,
   type CurrentDeploymentAuthority,
   type IacProvider,
+  type ProviderExecutionEvidence,
   type PreviewRequest,
 } from "./iac.js";
 import {
@@ -46,6 +47,11 @@ export interface NativeProviderRuntime {
 export interface PreviewBindingStore {
   save(previewHash: string, binding: PersistedPreviewBinding): Promise<void>;
   load(previewHash: string): Promise<PersistedPreviewBinding | undefined>;
+  loadLatest?(
+    projectId: string,
+    runId: string,
+    operation: "apply" | "destroy",
+  ): Promise<PersistedPreviewBinding | undefined>;
 }
 
 export interface EncryptedPlanArtifactStore {
@@ -99,6 +105,7 @@ abstract class NativeProviderBase {
   readonly #timeoutMs: number;
   readonly #maxOutputBytes: number;
   readonly #operations = new Map<string, OperationRecordV1>();
+  readonly #executionEvidence = new Map<string, ProviderExecutionEvidence>();
   protected readonly bindingStore: PreviewBindingStore | undefined;
 
   protected constructor(options: NativeProviderRuntime) {
@@ -156,6 +163,7 @@ abstract class NativeProviderBase {
     approval: ApprovalEvidenceV1,
     authority: CurrentDeploymentAuthority,
     providerOperationId?: string,
+    validatorIds: readonly string[] = [],
   ): OperationRecordV1 {
     const operationId = this.nextId();
     const record: OperationRecordV1 = {
@@ -172,11 +180,21 @@ abstract class NativeProviderBase {
       updatedAt: this.now().toISOString(),
     };
     this.#operations.set(operationId, record);
+    this.#executionEvidence.set(operationId, {
+      mode: "native",
+      operationId,
+      previewHash: preview.previewHash,
+      validatorIds: [...validatorIds],
+    });
     return record;
   }
 
   async reconcile(operationId: string): Promise<OperationRecordV1 | undefined> {
     return this.#operations.get(operationId);
+  }
+
+  executionEvidence(operationId: string): ProviderExecutionEvidence | undefined {
+    return this.#executionEvidence.get(operationId);
   }
 
   protected previewKey(request: PreviewRequest, operation: "apply" | "destroy"): string {
@@ -357,7 +375,10 @@ export class NativeBicepProvider extends NativeProviderBase implements IacProvid
     approval: ApprovalEvidenceV1,
     suppliedAuthority: CurrentDeploymentAuthority,
   ): Promise<OperationRecordV1> {
-    let binding = this.#bindings.get(`${preview.projectId}\u0000${preview.runId}\u0000${operation}`);
+    const key = `${preview.projectId}\u0000${preview.runId}\u0000${operation}`;
+    const restoredLatest = await this.bindingStore?.loadLatest?.(preview.projectId, preview.runId, operation);
+    const latestBinding = this.#bindings.get(key) ?? (restoredLatest?.kind === "bicep" ? restoredLatest : undefined);
+    let binding = latestBinding;
     if (binding === undefined) {
       const restored = await this.bindingStore?.load(preview.previewHash);
       if (restored?.kind === "bicep") binding = restored;
@@ -368,7 +389,7 @@ export class NativeBicepProvider extends NativeProviderBase implements IacProvid
       preview,
       approval,
       suppliedAuthority,
-      binding?.preview.previewHash,
+      latestBinding?.preview.previewHash ?? binding?.preview.previewHash,
     );
     if (binding === undefined || binding.preview.previewHash !== preview.previewHash) {
       throw new IacProviderError("PREVIEW_HASH_MISMATCH", "No exact Bicep stack binding is available for this preview");
@@ -399,7 +420,7 @@ export class NativeBicepProvider extends NativeProviderBase implements IacProvid
       const result = parseJsonProcessOutput("azure-stack", stdout) as Record<string, unknown>;
       providerOperationId = typeof result.id === "string" ? result.id : undefined;
     }
-    return this.record(operation, preview, approval, authority, providerOperationId);
+    return this.record(operation, preview, approval, authority, providerOperationId, ["deploy:bicep-stack-ownership"]);
   }
 }
 
@@ -637,7 +658,10 @@ export class NativeTerraformProvider extends NativeProviderBase implements IacPr
     );
     try {
       await this.run(this.#commands.applyExact(this.#target.cwd, handle.path));
-      return this.record(operation, preview, approval, authority, `terraform-plan:${binding.attestation.planDigest}`);
+      return this.record(operation, preview, approval, authority, `terraform-plan:${binding.attestation.planDigest}`, [
+        "deploy:exact-saved-plan",
+        "deploy:state-lineage-and-serial",
+      ]);
     } finally {
       await handle.dispose();
     }

--- a/packages/capabilities/src/test/native-iac-providers.test.ts
+++ b/packages/capabilities/src/test/native-iac-providers.test.ts
@@ -97,11 +97,23 @@ class FakeRunner implements ProcessRunnerLike {
 
 class MemoryBindingStore {
   readonly values = new Map<string, PersistedPreviewBinding>();
+  readonly latest = new Map<string, PersistedPreviewBinding>();
   async save(previewHash: string, binding: PersistedPreviewBinding): Promise<void> {
     this.values.set(previewHash, binding);
+    this.latest.set(
+      `${binding.preview.projectId}\u0000${binding.preview.runId}\u0000${binding.preview.operation}`,
+      binding,
+    );
   }
   async load(previewHash: string): Promise<PersistedPreviewBinding | undefined> {
     return this.values.get(previewHash);
+  }
+  async loadLatest(
+    projectId: string,
+    runId: string,
+    operation: "apply" | "destroy",
+  ): Promise<PersistedPreviewBinding | undefined> {
+    return this.latest.get(`${projectId}\u0000${runId}\u0000${operation}`);
   }
 }
 
@@ -208,7 +220,13 @@ test("native Bicep lifecycle binds fallback preview inputs/state and exact stack
   const provider = new NativeBicepProvider(options);
   const applyPreview = await provider.previewApply(request());
   const restarted = new NativeBicepProvider(options);
-  await restarted.apply(applyPreview, approval(applyPreview), authority);
+  const applyOperation = await restarted.apply(applyPreview, approval(applyPreview), authority);
+  assert.deepEqual(restarted.executionEvidence(applyOperation.operationId), {
+    mode: "native",
+    operationId: applyOperation.operationId,
+    previewHash: applyPreview.previewHash,
+    validatorIds: ["deploy:bicep-stack-ownership"],
+  });
   assert.equal(
     runner.requests.some((entry) => entry.args[2] === "create"),
     true,
@@ -248,6 +266,16 @@ test("native Bicep lifecycle binds fallback preview inputs/state and exact stack
   );
 
   current = authority;
+
+  const superseded = await provider.previewApply(request({ runId: "superseded" }));
+  await provider.previewApply(
+    request({ runId: "superseded", commit: "e".repeat(64), dependencyRevision: "e".repeat(64) }),
+  );
+  const supersededRestart = new NativeBicepProvider(options);
+  await assert.rejects(
+    supersededRestart.apply(superseded, approval(superseded), authority),
+    (error) => error instanceof IacProviderError && error.code === "PREVIEW_SUPERSEDED",
+  );
   const mutationPreview = await provider.previewApply(request({ runId: "mutated" }));
   await writeFile(join(root, "main.bicep"), "targetScope = 'subscription'\n");
   await assert.rejects(
@@ -351,7 +379,13 @@ test("native Terraform encrypts immediately and restores exact-plan binding afte
   assert.equal("savedPlanPath" in (provider.attestation(applyPreview.previewHash) ?? {}), false);
 
   const restarted = new NativeTerraformProvider(options);
-  await restarted.apply(applyPreview, approval(applyPreview), authority);
+  const applyOperation = await restarted.apply(applyPreview, approval(applyPreview), authority);
+  assert.deepEqual(restarted.executionEvidence(applyOperation.operationId), {
+    mode: "native",
+    operationId: applyOperation.operationId,
+    previewHash: applyPreview.previewHash,
+    validatorIds: ["deploy:exact-saved-plan", "deploy:state-lineage-and-serial"],
+  });
   const exactApply = runner.requests.at(-1);
   assert.equal(exactApply?.args[0], "apply");
   assert.match(exactApply?.args[2] ?? "", /apex-local-plan-/);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -122,7 +122,19 @@ async function configuredProviders(
       ownerEpoch: run.ownerEpoch,
       artifacts,
     });
-    return { head: dependencyRevision, dependencyRevision, ownerEpoch: run.ownerEpoch, recipientIdentity: "local" };
+    let recipientIdentity = "local";
+    try {
+      const ownership = JSON.parse(await readFile(join(runDirectory, "ownership.json"), "utf8")) as {
+        ownerId?: unknown;
+        ownerEpoch?: unknown;
+      };
+      if (ownership.ownerEpoch === run.ownerEpoch && typeof ownership.ownerId === "string") {
+        recipientIdentity = ownership.ownerId;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    return { head: dependencyRevision, dependencyRevision, ownerEpoch: run.ownerEpoch, recipientIdentity };
   };
   const providers: Partial<Record<"bicep" | "terraform", IacProvider>> = {};
   if (config.bicep !== undefined) {

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -35,6 +35,7 @@ import {
   type LogicalResourceManifestV1,
   type ImplementationIntentV1,
   type Operation,
+  type OperationRecordV1,
   type ProjectId,
   type ResourceInventoryV1,
   type ReviewFindingsV1,
@@ -54,6 +55,7 @@ import {
   generateTerraformTree,
   type CapabilityPackInstallOptions,
   type IacProvider,
+  type ProviderExecutionEvidence,
   type ProcessRunnerLike,
 } from "@apex/capabilities";
 import {
@@ -95,6 +97,7 @@ import {
   registerWorkflowValidators,
   taskWorkflowValidatorInput,
   type WorkflowGateValidatorContext,
+  type WorkflowDeployValidatorContext,
   type WorkflowPreviewValidatorContext,
   type WorkflowTaskValidatorContext,
 } from "./workflow-validators.js";
@@ -994,6 +997,7 @@ export class ApexService {
     if (gateNumber === 4 && previewHash === undefined) {
       throw new ApexError("APEX_VALIDATION", "Gate 4 requires a deployment preview", EXIT_CODES.validation);
     }
+    const recipientIdentity = await this.currentRecipientIdentity(run);
     const decidedAt = this.clock().toISOString();
     const approval: ApprovalEvidenceV1 = {
       schemaVersion: CONTRACT_VERSION,
@@ -1003,7 +1007,7 @@ export class ApexService {
       decision,
       actor,
       mechanism: "tty",
-      recipientIdentity: "local",
+      recipientIdentity,
       dependencyHash: gate.dependencyHash,
       ...(previewHash === undefined ? {} : { previewHash }),
       writerEpoch: run.ownerEpoch,
@@ -1183,6 +1187,36 @@ export class ApexService {
     if (previewHash === undefined || previewObjectHash === undefined || approvalHash === undefined) {
       throw new ApexError("APEX_AUTHORIZATION", "Preview and Gate 4 approval are required", EXIT_CODES.authorization);
     }
+    const completed = [...events]
+      .reverse()
+      .find(
+        (event) =>
+          event.type === "deployment.completed" &&
+          (event.payload as { previewHash?: unknown }).previewHash === previewHash,
+      );
+    if (completed !== undefined) {
+      const payload = completed.payload as { operationHash?: unknown; inventoryHash?: unknown };
+      if (typeof payload.operationHash === "string" && typeof payload.inventoryHash === "string") {
+        return {
+          operation: await this.objects.getJson<OperationRecordV1>(payload.operationHash),
+          inventory: await this.objects.getJson<ResourceInventoryV1>(payload.inventoryHash),
+        };
+      }
+    }
+    const incompleteExecution = [...events]
+      .reverse()
+      .find(
+        (event) =>
+          (event.type === "deployment.executed" || event.type === "deployment.indeterminate") &&
+          (event.payload as { previewHash?: unknown }).previewHash === previewHash,
+      );
+    if (incompleteExecution !== undefined) {
+      throw new ApexError(
+        "APEX_CONFLICT",
+        "Deployment outcome is incomplete or indeterminate; run reconcile before retrying",
+        EXIT_CODES.conflict,
+      );
+    }
     if (expectedPreviewHash !== undefined && expectedPreviewHash !== previewHash) {
       throw new ApexError("APEX_STALE", "Requested preview hash is not current", EXIT_CODES.stale);
     }
@@ -1208,6 +1242,18 @@ export class ApexService {
     }
     const providerName = [...events].reverse().find((event) => event.type === "preview.created")?.payload as
       { provider?: unknown } | undefined;
+    const provider =
+      providerName?.provider === "bicep" || providerName?.provider === "terraform" ? providerName.provider : "fake";
+    const commonValidatorIds = await this.validateDeployValidators(
+      run,
+      provider,
+      preview,
+      approval,
+      previewHash,
+      dependencyRevision,
+      "pre",
+    );
+    const declaredValidatorIds = await this.deployValidatorIds(run);
     if (providerName?.provider === "bicep" || providerName?.provider === "terraform") {
       const provider = this.providers[providerName.provider];
       if (provider === undefined)
@@ -1216,33 +1262,55 @@ export class ApexService {
           `${providerName.provider} provider is no longer configured`,
           EXIT_CODES.validation,
         );
-      const operation =
-        preview.operation === "apply"
-          ? await provider.apply(preview, approval, {
-              head: preview.commit,
-              dependencyRevision,
-              ownerEpoch: run.ownerEpoch,
-              recipientIdentity: approval.recipientIdentity ?? "local",
-            })
-          : await provider.destroy(preview, approval, {
-              head: preview.commit,
-              dependencyRevision,
-              ownerEpoch: run.ownerEpoch,
-              recipientIdentity: approval.recipientIdentity ?? "local",
-            });
-      this.assertValid("operation", operation);
-      const operationHash = await this.objects.putJson(operation);
-      const inventory = await provider.inventory(run.projectId, run.runId);
-      this.assertValid("inventory", inventory);
-      const inventoryHash = await this.objects.putJson(inventory);
-      await this.append(run, "deployment.completed", {
-        operationHash,
-        inventoryHash,
+      let operation: OperationRecordV1;
+      try {
+        operation =
+          preview.operation === "apply"
+            ? await provider.apply(preview, approval, {
+                head: preview.commit,
+                dependencyRevision,
+                ownerEpoch: run.ownerEpoch,
+                recipientIdentity: approval.recipientIdentity ?? "local",
+              })
+            : await provider.destroy(preview, approval, {
+                head: preview.commit,
+                dependencyRevision,
+                ownerEpoch: run.ownerEpoch,
+                recipientIdentity: approval.recipientIdentity ?? "local",
+              });
+      } catch (error) {
+        await this.append(run, "deployment.indeterminate", {
+          provider: providerName.provider,
+          previewHash,
+          approvalHash,
+          preValidatorIds: commonValidatorIds,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+      const executionEvidence = provider.executionEvidence?.(operation.operationId);
+      await this.append(run, "deployment.executed", {
+        provider: providerName.provider,
         previewHash,
         approvalHash,
-        provider: providerName.provider,
+        operation: operation as unknown as JsonValue,
+        preValidatorIds: commonValidatorIds,
+        ...(executionEvidence === undefined ? {} : { executionEvidence: executionEvidence as unknown as JsonValue }),
       });
-      return { operation, inventory };
+      return this.completeNativeDeployment(
+        run,
+        events,
+        providerName.provider,
+        provider,
+        preview,
+        approval,
+        previewHash,
+        approvalHash,
+        dependencyRevision,
+        commonValidatorIds,
+        operation,
+        executionEvidence,
+      );
     }
     const now = this.clock().toISOString();
     const operation = {
@@ -1254,7 +1322,7 @@ export class ApexService {
       operation: preview.operation,
       state: "succeeded" as const,
       previewHash,
-      approvalHash,
+      approvalHash: sha256Json(approval),
       ownerEpoch: run.ownerEpoch,
       updatedAt: now,
     };
@@ -1279,7 +1347,82 @@ export class ApexService {
     };
     this.assertValid("inventory", inventory);
     const inventoryHash = await this.objects.putJson(inventory);
-    await this.append(run, "deployment.completed", { operationHash, inventoryHash, previewHash, approvalHash });
+    const omittedValidatorIds = declaredValidatorIds.filter((id) => !commonValidatorIds.includes(id));
+    await this.append(run, "deployment.completed", {
+      operationHash,
+      inventoryHash,
+      previewHash,
+      approvalHash,
+      validatorIds: commonValidatorIds,
+      preValidatorIds: commonValidatorIds,
+      postValidatorIds: [],
+      ...(omittedValidatorIds.length === 0 ? {} : { omittedValidatorIds }),
+      evidenceMode: "simulated",
+    });
+    return { operation, inventory };
+  }
+
+  private async completeNativeDeployment(
+    run: RunConfigV1,
+    events: Awaited<ReturnType<EventJournal["replay"]>>,
+    providerName: "bicep" | "terraform",
+    provider: IacProvider,
+    preview: DeploymentPreviewV1,
+    approval: ApprovalEvidenceV1,
+    previewHash: string,
+    approvalHash: string,
+    dependencyRevision: string,
+    commonValidatorIds: string[],
+    operation: OperationRecordV1,
+    executionEvidence?: ProviderExecutionEvidence,
+  ): Promise<{ operation: unknown; inventory: ResourceInventoryV1 }> {
+    this.assertValid("operation", operation);
+    let attestation: ExecutionPlanAttestationV1 | undefined;
+    if (providerName === "terraform") {
+      const attestationHash = this.latestPayloadHash(events, "preview.created", "attestationHash");
+      if (attestationHash !== undefined) {
+        attestation = await this.objects.getJson<ExecutionPlanAttestationV1>(attestationHash);
+        this.assertValid("execution-plan-attestation", attestation);
+      }
+    }
+    const providerValidatorIds = await this.validateDeployValidators(
+      run,
+      providerName,
+      preview,
+      approval,
+      previewHash,
+      dependencyRevision,
+      "post",
+      operation,
+      executionEvidence,
+      attestation,
+    );
+    if (
+      executionEvidence === undefined ||
+      JSON.stringify(executionEvidence.validatorIds) !== JSON.stringify(providerValidatorIds)
+    ) {
+      throw new ApexError(
+        "APEX_VALIDATION",
+        "Provider execution receipt validator IDs do not match the workflow manifest",
+        EXIT_CODES.validation,
+      );
+    }
+    const operationHash = await this.objects.putJson(operation);
+    const inventory = await provider.inventory(run.projectId, run.runId);
+    this.assertValid("inventory", inventory);
+    const inventoryHash = await this.objects.putJson(inventory);
+    const declaredValidatorIds = await this.deployValidatorIds(run);
+    await this.append(run, "deployment.completed", {
+      operationHash,
+      inventoryHash,
+      previewHash,
+      approvalHash,
+      provider: providerName,
+      validatorIds: declaredValidatorIds.filter((id) => [...commonValidatorIds, ...providerValidatorIds].includes(id)),
+      preValidatorIds: commonValidatorIds,
+      postValidatorIds: providerValidatorIds,
+      evidenceMode: "native",
+    });
     return { operation, inventory };
   }
 
@@ -1538,6 +1681,14 @@ export class ApexService {
     return new WriterTransferStore(this.projects.runDirectory(run.projectId, run.runId), this.clock).currentOwnership();
   }
 
+  private async currentRecipientIdentity(run: RunConfigV1): Promise<string> {
+    const ownership = await new WriterTransferStore(
+      this.projects.runDirectory(run.projectId, run.runId),
+      this.clock,
+    ).currentOwnership();
+    return ownership?.ownerEpoch === run.ownerEpoch ? ownership.ownerId : "local";
+  }
+
   async acceptEvidence(input: {
     kind: string;
     contentType: string;
@@ -1641,9 +1792,68 @@ export class ApexService {
     return { status: await this.status(), doctor: await this.doctor() };
   }
   async reconcile(): Promise<unknown> {
-    const inventory = await this.inventory();
-    await this.append(await this.currentRun(), "deployment.reconciled", { deploymentHash: inventory.deploymentHash });
-    return inventory;
+    const run = await this.currentRun();
+    const events = await this.journal(run).replay();
+    const completedInventoryHash = this.latestPayloadHash(events, "deployment.completed", "inventoryHash");
+    if (completedInventoryHash !== undefined) {
+      const inventory = await this.objects.getJson<ResourceInventoryV1>(completedInventoryHash);
+      await this.append(run, "deployment.reconciled", { deploymentHash: inventory.deploymentHash });
+      return inventory;
+    }
+    const executed = [...events].reverse().find((event) => event.type === "deployment.executed");
+    if (executed === undefined)
+      throw new ApexError("APEX_NOT_FOUND", "No deployment execution exists for this run", EXIT_CODES.notFound);
+    const payload = executed.payload as {
+      provider?: unknown;
+      previewHash?: unknown;
+      approvalHash?: unknown;
+      operation?: unknown;
+      preValidatorIds?: unknown;
+      executionEvidence?: unknown;
+    };
+    if (
+      (payload.provider !== "bicep" && payload.provider !== "terraform") ||
+      typeof payload.previewHash !== "string" ||
+      typeof payload.approvalHash !== "string" ||
+      payload.operation === null ||
+      typeof payload.operation !== "object" ||
+      !Array.isArray(payload.preValidatorIds)
+    ) {
+      throw new ApexError("APEX_VALIDATION", "Deployment execution receipt is invalid", EXIT_CODES.validation);
+    }
+    const provider = this.providers[payload.provider];
+    if (provider === undefined)
+      throw new ApexError(
+        "APEX_VALIDATION",
+        `${payload.provider} provider is required to reconcile deployment inventory`,
+        EXIT_CODES.validation,
+      );
+    const previewObjectHash = this.latestPayloadHash(
+      events,
+      "preview.created",
+      "previewObjectHash",
+      (candidate) => candidate.previewHash === payload.previewHash,
+    );
+    if (previewObjectHash === undefined)
+      throw new ApexError("APEX_VALIDATION", "Executed deployment preview object is missing", EXIT_CODES.validation);
+    const preview = await this.objects.getJson<DeploymentPreviewV1>(previewObjectHash);
+    const approval = await this.objects.getJson<ApprovalEvidenceV1>(payload.approvalHash);
+    const completed = await this.completeNativeDeployment(
+      run,
+      events,
+      payload.provider,
+      provider,
+      preview,
+      approval,
+      payload.previewHash,
+      payload.approvalHash,
+      preview.dependencyRevision,
+      payload.preValidatorIds.filter((id): id is string => typeof id === "string"),
+      payload.operation as OperationRecordV1,
+      payload.executionEvidence as ProviderExecutionEvidence | undefined,
+    );
+    await this.append(run, "deployment.reconciled", { deploymentHash: completed.inventory.deploymentHash });
+    return completed.inventory;
   }
   async setup(live = false): Promise<unknown> {
     return this.doctor(false, false, live);
@@ -1879,6 +2089,9 @@ export class ApexService {
         continue;
       }
       if (descriptor.id === "diagnosis" && !events.some(({ type }) => type === "deployment.completed")) {
+        if (events.some(({ type }) => type === "deployment.executed" || type === "deployment.indeterminate")) {
+          return { blockers: ["Deployment executed but requires reconciliation"] };
+        }
         const preview = this.latestPayloadHash(events, "preview.created", "previewHash");
         if (preview === undefined) return { blockers: ["Deployment preview is required"] };
         if (!this.gateApproved(run, 4)) return { blockers: ["Gate 4 approval is required"] };
@@ -2356,6 +2569,7 @@ export class ApexService {
       reviewBlockers: reviewNodes.flatMap((reviewNode) => this.reviewBlockers(events, reviewNode)),
       currentDependencyRevision: this.dependencyRevision(run, events),
       legacyRequirements,
+      currentRecipientIdentity: await this.currentRecipientIdentity(run),
       ...(expectedDependencyHash === undefined ? {} : { expectedDependencyHash }),
       ...(preview === undefined ? {} : { preview }),
     };
@@ -2401,6 +2615,56 @@ export class ApexService {
     };
     for (const id of validatorIds) this.assertValid(id, context);
     return { validatorIds, omittedValidatorIds, evidenceMode: provider === "fake" ? "simulated" : "native" };
+  }
+
+  private async validateDeployValidators(
+    run: RunConfigV1,
+    provider: "fake" | "bicep" | "terraform",
+    preview: DeploymentPreviewV1,
+    approval: ApprovalEvidenceV1,
+    expectedPreviewHash: string,
+    currentDependencyRevision: string,
+    phase: "pre" | "post",
+    operation?: OperationRecordV1,
+    executionEvidence?: ProviderExecutionEvidence,
+    attestation?: ExecutionPlanAttestationV1,
+  ): Promise<string[]> {
+    const workflow = new WorkflowEngine(
+      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
+    );
+    const nodeId = `deploy-${run.iacTool}`;
+    const node = workflow.manifest.nodes.find(({ id }) => id === nodeId);
+    if (node === undefined) throw new Error(`Workflow deployment ${nodeId} has no manifest node`);
+    const owner = phase === "pre" ? "@apex/cli" : "@apex/capabilities";
+    const validatorIds = node.validators.filter((id) => {
+      const ownership = workflowValidatorOwnership(id);
+      return ownership?.boundary === "deploy" && ownership.owner === owner;
+    });
+    const context: WorkflowDeployValidatorContext = {
+      now: this.clock().toISOString(),
+      run,
+      provider,
+      preview,
+      approval,
+      expectedPreviewHash,
+      currentDependencyRevision,
+      ...(operation === undefined ? {} : { operation }),
+      ...(executionEvidence === undefined ? {} : { executionEvidence }),
+      ...(attestation === undefined ? {} : { attestation }),
+    };
+    for (const id of validatorIds) this.assertValid(id, context);
+    return validatorIds;
+  }
+
+  private async deployValidatorIds(run: RunConfigV1): Promise<string[]> {
+    const workflow = new WorkflowEngine(
+      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
+    );
+    return (
+      workflow.manifest.nodes
+        .find(({ id }) => id === `deploy-${run.iacTool}`)
+        ?.validators.filter((id) => workflowValidatorOwnership(id)?.boundary === "deploy") ?? []
+    );
   }
 
   private initialSkuManifest(run: RunConfigV1, requirements: unknown): unknown {

--- a/packages/cli/src/test/expanded-workflow.test.ts
+++ b/packages/cli/src/test/expanded-workflow.test.ts
@@ -117,11 +117,15 @@ async function reachValidation(service: ApexService, runId: string, track: "bice
 
 function terraformPreviewProvider(
   now: Date,
-  mutation?: "input-hash" | "operation" | "state",
+  mutation?:
+    "input-hash" | "operation" | "state" | "apply-error" | "missing-receipt" | "extra-receipt" | "inventory-once",
 ): IacProvider & {
   attestation(previewHash: string): ExecutionPlanAttestationV1 | undefined;
 } {
   let attestation: ExecutionPlanAttestationV1 | undefined;
+  let executionEvidence:
+    { mode: "native"; operationId: string; previewHash: string; validatorIds: string[] } | undefined;
+  let inventoryCalls = 0;
   const createPreview = async (request: PreviewRequest): Promise<DeploymentPreviewV1> => {
     const plan = {
       planDigest: "1".repeat(64),
@@ -188,17 +192,124 @@ function terraformPreviewProvider(
     validate: async () => [],
     previewApply: createPreview,
     previewDestroy: createPreview,
-    apply: async () => {
-      throw new Error("not used");
+    apply: async (preview, approval, authority) => {
+      if (mutation === "apply-error") throw new Error("provider apply outcome is unknown");
+      const operation = {
+        schemaVersion: "1.0.0" as const,
+        operationId: "terraform-operation",
+        projectId: preview.projectId,
+        runId: preview.runId,
+        providerOperationId: "terraform-plan:test",
+        operation: preview.operation,
+        state: "succeeded" as const,
+        previewHash: preview.previewHash,
+        approvalHash: sha256Json(approval),
+        ownerEpoch: authority.ownerEpoch,
+        updatedAt: now.toISOString(),
+      };
+      if (mutation !== "missing-receipt") {
+        executionEvidence = {
+          mode: "native",
+          operationId: operation.operationId,
+          previewHash: preview.previewHash,
+          validatorIds: [
+            "deploy:exact-saved-plan",
+            "deploy:state-lineage-and-serial",
+            ...(mutation === "extra-receipt" ? ["deploy:undeclared"] : []),
+          ],
+        };
+      }
+      return operation;
     },
     destroy: async () => {
       throw new Error("not used");
     },
-    inventory: async () => {
-      throw new Error("not used");
+    inventory: async (projectId, runId) => {
+      inventoryCalls += 1;
+      if (mutation === "inventory-once" && inventoryCalls === 1) throw new Error("inventory unavailable");
+      return {
+        schemaVersion: "1.0.0" as const,
+        projectId,
+        runId,
+        deploymentHash: "9".repeat(64),
+        collectedAt: now.toISOString(),
+        resources: [],
+      };
     },
     reconcile: async () => undefined,
     attestation: (previewHash) => (attestation?.previewHash === previewHash ? attestation : undefined),
+    executionEvidence: (operationId) =>
+      executionEvidence?.operationId === operationId ? executionEvidence : undefined,
+  };
+}
+
+function bicepPreviewProvider(now: Date): IacProvider {
+  let executionEvidence:
+    { mode: "native"; operationId: string; previewHash: string; validatorIds: string[] } | undefined;
+  const createPreview = async (request: PreviewRequest): Promise<DeploymentPreviewV1> => {
+    const base = {
+      schemaVersion: "1.0.0" as const,
+      projectId: request.projectId,
+      runId: request.runId,
+      environment: request.environment as "dev",
+      track: "bicep" as const,
+      operation: "apply" as const,
+      target: request.target,
+      commit: request.commit,
+      dependencyRevision: request.dependencyRevision,
+      ownerEpoch: request.ownerEpoch,
+      inputHash: request.inputHash,
+      iacHash: request.iacHash,
+      policyHash: request.policyHash,
+      artifactHash: "8".repeat(64),
+      changes: request.resources.map(({ resourceId }) => ({ resourceId, action: "create" as const, material: true })),
+      blockers: [],
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + request.ttlMs).toISOString(),
+    };
+    return { ...base, previewHash: sha256Json(base) };
+  };
+  return {
+    track: "bicep",
+    validate: async () => [],
+    previewApply: createPreview,
+    previewDestroy: createPreview,
+    apply: async (preview, approval, authority) => {
+      const operation = {
+        schemaVersion: "1.0.0" as const,
+        operationId: "bicep-operation",
+        projectId: preview.projectId,
+        runId: preview.runId,
+        providerOperationId: "/stack/workload",
+        operation: preview.operation,
+        state: "succeeded" as const,
+        previewHash: preview.previewHash,
+        approvalHash: sha256Json(approval),
+        ownerEpoch: authority.ownerEpoch,
+        updatedAt: now.toISOString(),
+      };
+      executionEvidence = {
+        mode: "native",
+        operationId: operation.operationId,
+        previewHash: preview.previewHash,
+        validatorIds: ["deploy:bicep-stack-ownership"],
+      };
+      return operation;
+    },
+    destroy: async () => {
+      throw new Error("not used");
+    },
+    inventory: async (projectId, runId) => ({
+      schemaVersion: "1.0.0",
+      projectId,
+      runId,
+      deploymentHash: "7".repeat(64),
+      collectedAt: now.toISOString(),
+      resources: [],
+    }),
+    reconcile: async () => undefined,
+    executionEvidence: (operationId) =>
+      executionEvidence?.operationId === operationId ? executionEvidence : undefined,
   };
 }
 
@@ -564,6 +675,26 @@ for (const track of ["bicep", "terraform"] as const) {
     await service.decideGateNumber(4, "approved", "tester");
     const deployed = await service.deploy(preview.previewHash);
     assert.equal(deployed.inventory.resources.length, 1);
+    const deploymentEvents = await new EventJournal(
+      join(root, ".apex", "projects", "demo", "runs", runId, "journal"),
+    ).replay();
+    const deployment = [...deploymentEvents].reverse().find((event) => event.type === "deployment.completed");
+    assert.deepEqual((deployment?.payload as { validatorIds?: unknown }).validatorIds, [
+      "deploy:exact-approved-operation",
+      "deploy:stale-writer-rejection",
+    ]);
+    assert.deepEqual((deployment?.payload as { preValidatorIds?: unknown }).preValidatorIds, [
+      "deploy:exact-approved-operation",
+      "deploy:stale-writer-rejection",
+    ]);
+    assert.deepEqual((deployment?.payload as { postValidatorIds?: unknown }).postValidatorIds, []);
+    assert.deepEqual(
+      (deployment?.payload as { omittedValidatorIds?: unknown }).omittedValidatorIds,
+      track === "bicep"
+        ? ["deploy:bicep-stack-ownership"]
+        : ["deploy:exact-saved-plan", "deploy:state-lineage-and-serial"],
+    );
+    assert.equal((deployment?.payload as { evidenceMode?: unknown }).evidenceMode, "simulated");
     await complete(service, "diagnosis", [
       {
         kind: "diagnosis",
@@ -646,6 +777,32 @@ for (const track of ["bicep", "terraform"] as const) {
   });
 }
 
+test("native Bicep deploy records stack ownership evidence in manifest order", async () => {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  const root = await tempRoot();
+  const service = new ApexService(root, { clock: () => now, providers: { bicep: bicepPreviewProvider(now) } });
+  const { runId } = await service.init({ projectId: "demo", iacTool: "bicep" });
+  await reachValidation(service, runId, "bicep");
+  const preview = await service.preview({ operation: "apply", provider: "bicep" });
+  await service.decideGateNumber(4, "approved", "tester");
+  await service.deploy(preview.previewHash);
+  const events = await new EventJournal(join(root, ".apex", "projects", "demo", "runs", runId, "journal")).replay();
+  const completed = [...events].reverse().find((event) => event.type === "deployment.completed");
+  assert.deepEqual((completed?.payload as { validatorIds?: unknown }).validatorIds, [
+    "deploy:exact-approved-operation",
+    "deploy:bicep-stack-ownership",
+    "deploy:stale-writer-rejection",
+  ]);
+  assert.deepEqual((completed?.payload as { preValidatorIds?: unknown }).preValidatorIds, [
+    "deploy:exact-approved-operation",
+    "deploy:stale-writer-rejection",
+  ]);
+  assert.deepEqual((completed?.payload as { postValidatorIds?: unknown }).postValidatorIds, [
+    "deploy:bicep-stack-ownership",
+  ]);
+  assert.equal((completed?.payload as { evidenceMode?: unknown }).evidenceMode, "native");
+});
+
 test("native Terraform preview records saved-plan validation and rejects wrong bindings", async () => {
   const now = new Date("2026-01-01T00:00:00.000Z");
   const root = await tempRoot();
@@ -653,7 +810,7 @@ test("native Terraform preview records saved-plan validation and rejects wrong b
   const service = new ApexService(root, { clock: () => now, providers: { terraform: provider } });
   const { runId } = await service.init({ projectId: "demo", iacTool: "terraform" });
   await reachValidation(service, runId, "terraform");
-  await service.preview({ operation: "apply", provider: "terraform" });
+  const preview = await service.preview({ operation: "apply", provider: "terraform" });
   const events = await new EventJournal(join(root, ".apex", "projects", "demo", "runs", runId, "journal")).replay();
   const created = [...events].reverse().find((event) => event.type === "preview.created");
   assert.deepEqual((created?.payload as { validatorIds?: unknown }).validatorIds, [
@@ -665,6 +822,107 @@ test("native Terraform preview records saved-plan validation and rejects wrong b
   ]);
   assert.equal((created?.payload as { evidenceMode?: unknown }).evidenceMode, "native");
   assert.match((created?.payload as { attestationHash?: string }).attestationHash!, /^[0-9a-f]{64}$/);
+  await service.decideGateNumber(4, "approved", "tester");
+  await service.deploy(preview.previewHash);
+  const completedEvents = await new EventJournal(
+    join(root, ".apex", "projects", "demo", "runs", runId, "journal"),
+  ).replay();
+  const deployment = [...completedEvents].reverse().find((event) => event.type === "deployment.completed");
+  assert.deepEqual((deployment?.payload as { validatorIds?: unknown }).validatorIds, [
+    "deploy:exact-approved-operation",
+    "deploy:exact-saved-plan",
+    "deploy:state-lineage-and-serial",
+    "deploy:stale-writer-rejection",
+  ]);
+  assert.deepEqual((deployment?.payload as { preValidatorIds?: unknown }).preValidatorIds, [
+    "deploy:exact-approved-operation",
+    "deploy:stale-writer-rejection",
+  ]);
+  assert.deepEqual((deployment?.payload as { postValidatorIds?: unknown }).postValidatorIds, [
+    "deploy:exact-saved-plan",
+    "deploy:state-lineage-and-serial",
+  ]);
+  assert.equal((deployment?.payload as { evidenceMode?: unknown }).evidenceMode, "native");
+  assert.equal((deployment?.payload as { omittedValidatorIds?: unknown }).omittedValidatorIds, undefined);
+
+  const receiptRoot = await tempRoot();
+  const missingReceipt = new ApexService(receiptRoot, {
+    clock: () => now,
+    providers: { terraform: terraformPreviewProvider(now, "missing-receipt") },
+  });
+  const receiptRun = await missingReceipt.init({ projectId: "demo", iacTool: "terraform" });
+  await reachValidation(missingReceipt, receiptRun.runId, "terraform");
+  const receiptPreview = await missingReceipt.preview({ operation: "apply", provider: "terraform" });
+  await missingReceipt.decideGateNumber(4, "approved", "tester");
+  await assert.rejects(missingReceipt.deploy(receiptPreview.previewHash), /deploy:exact-saved-plan/);
+  const receiptEvents = await new EventJournal(
+    join(receiptRoot, ".apex", "projects", "demo", "runs", receiptRun.runId, "journal"),
+  ).replay();
+  assert.equal(
+    receiptEvents.some(({ type }) => type === "deployment.executed"),
+    true,
+  );
+  assert.equal(
+    receiptEvents.some(({ type }) => type === "deployment.completed"),
+    false,
+  );
+  await assert.rejects(missingReceipt.deploy(receiptPreview.previewHash), /run reconcile before retrying/);
+  assert.match((await missingReceipt.status()).blockers.join(" "), /requires reconciliation/);
+
+  const extraRoot = await tempRoot();
+  const extraReceipt = new ApexService(extraRoot, {
+    clock: () => now,
+    providers: { terraform: terraformPreviewProvider(now, "extra-receipt") },
+  });
+  const extraRun = await extraReceipt.init({ projectId: "demo", iacTool: "terraform" });
+  await reachValidation(extraReceipt, extraRun.runId, "terraform");
+  const extraPreview = await extraReceipt.preview({ operation: "apply", provider: "terraform" });
+  await extraReceipt.decideGateNumber(4, "approved", "tester");
+  await assert.rejects(extraReceipt.deploy(extraPreview.previewHash), /receipt validator IDs/);
+
+  const reconcileRoot = await tempRoot();
+  const reconcileProvider = terraformPreviewProvider(now, "inventory-once");
+  const reconciling = new ApexService(reconcileRoot, {
+    clock: () => now,
+    providers: { terraform: reconcileProvider },
+  });
+  const reconcileRun = await reconciling.init({ projectId: "demo", iacTool: "terraform" });
+  await reachValidation(reconciling, reconcileRun.runId, "terraform");
+  const reconcilePreview = await reconciling.preview({ operation: "apply", provider: "terraform" });
+  await reconciling.decideGateNumber(4, "approved", "tester");
+  await assert.rejects(reconciling.deploy(reconcilePreview.previewHash), /inventory unavailable/);
+  await assert.rejects(reconciling.deploy(reconcilePreview.previewHash), /run reconcile before retrying/);
+  const reconciled = (await reconciling.reconcile()) as { deploymentHash: string };
+  assert.equal(reconciled.deploymentHash, "9".repeat(64));
+  await reconciling.deploy(reconcilePreview.previewHash);
+  const reconciledEvents = await new EventJournal(
+    join(reconcileRoot, ".apex", "projects", "demo", "runs", reconcileRun.runId, "journal"),
+  ).replay();
+  assert.equal(reconciledEvents.filter(({ type }) => type === "deployment.executed").length, 1);
+  assert.equal(reconciledEvents.filter(({ type }) => type === "deployment.completed").length, 1);
+
+  const indeterminateRoot = await tempRoot();
+  const indeterminate = new ApexService(indeterminateRoot, {
+    clock: () => now,
+    providers: { terraform: terraformPreviewProvider(now, "apply-error") },
+  });
+  const indeterminateRun = await indeterminate.init({ projectId: "demo", iacTool: "terraform" });
+  await reachValidation(indeterminate, indeterminateRun.runId, "terraform");
+  const indeterminatePreview = await indeterminate.preview({ operation: "apply", provider: "terraform" });
+  await indeterminate.decideGateNumber(4, "approved", "tester");
+  await assert.rejects(indeterminate.deploy(indeterminatePreview.previewHash), /outcome is unknown/);
+  await assert.rejects(indeterminate.deploy(indeterminatePreview.previewHash), /run reconcile before retrying/);
+  const indeterminateEvents = await new EventJournal(
+    join(indeterminateRoot, ".apex", "projects", "demo", "runs", indeterminateRun.runId, "journal"),
+  ).replay();
+  assert.equal(
+    indeterminateEvents.some(({ type }) => type === "deployment.indeterminate"),
+    true,
+  );
+  assert.equal(
+    indeterminateEvents.some(({ type }) => type === "deployment.completed"),
+    false,
+  );
 
   const invalidRoot = await tempRoot();
   const invalid = new ApexService(invalidRoot, {

--- a/packages/cli/src/test/workflow.test.ts
+++ b/packages/cli/src/test/workflow.test.ts
@@ -39,6 +39,23 @@ test("full requirements to fake deploy workflow survives restart", async () => {
   ]);
   const deployed = await service.deploy(preview.previewHash);
   assert.equal(deployed.inventory.resources.length, 1);
+  const deploymentEvents = await new EventJournal(
+    join(root, ".apex", "projects", "demo", "runs", initialized.runId, "journal"),
+  ).replay();
+  const completed = [...deploymentEvents].reverse().find((event) => event.type === "deployment.completed");
+  assert.deepEqual((completed?.payload as { validatorIds?: unknown }).validatorIds, [
+    "deploy:exact-approved-operation",
+    "deploy:stale-writer-rejection",
+  ]);
+  assert.deepEqual((completed?.payload as { preValidatorIds?: unknown }).preValidatorIds, [
+    "deploy:exact-approved-operation",
+    "deploy:stale-writer-rejection",
+  ]);
+  assert.deepEqual((completed?.payload as { postValidatorIds?: unknown }).postValidatorIds, []);
+  assert.deepEqual((completed?.payload as { omittedValidatorIds?: unknown }).omittedValidatorIds, [
+    "deploy:bicep-stack-ownership",
+  ]);
+  assert.equal((completed?.payload as { evidenceMode?: unknown }).evidenceMode, "simulated");
 
   const restarted = new ApexService(root);
   assert.equal((await restarted.inventory()).deploymentHash, deployed.inventory.deploymentHash);
@@ -147,4 +164,24 @@ test("deploy rejects a preview and approval from an older owner epoch", async ()
     service.deploy(preview.previewHash),
     (error: unknown) => error instanceof ApexError && error.code === "APEX_STALE",
   );
+});
+
+test("Gate 4 approval binds the current transferred writer identity", async () => {
+  const service = new ApexService(await tempRoot());
+  const initialized = await service.init({ projectId: "demo" });
+  await prepareValidatedRun(service, initialized.runId, "bicep");
+  const transfer = (await service.createWriterTransfer({
+    repository: "owner/repo",
+    branch: "feat/run",
+    commit: "abc",
+    workflowId: "deploy",
+    sender: "local",
+    recipient: "ci",
+    currentHead: "abc",
+    ttlMs: 60_000,
+  })) as { hash: string };
+  await service.acceptWriterTransfer(transfer.hash, "ci", "abc");
+  await service.preview({ operation: "apply", provider: "fake" });
+  const approval = await service.decideGateNumber(4, "approved", "tester");
+  assert.equal(approval.recipientIdentity, "ci");
 });

--- a/packages/cli/src/workflow-validators.ts
+++ b/packages/cli/src/workflow-validators.ts
@@ -17,6 +17,7 @@ import {
   type IacBindingV1,
   type ImplementationIntentV1,
   type LogicalResourceManifestV1,
+  type OperationRecordV1,
   type PolicyPropertyMapV1,
   type QualityMeasurementsV1,
   type QualityReportV1,
@@ -55,6 +56,7 @@ export interface WorkflowGateValidatorContext {
   readonly expectedDependencyHash?: string;
   readonly currentDependencyRevision: string;
   readonly legacyRequirements: boolean;
+  readonly currentRecipientIdentity: string;
   readonly preview?: DeploymentPreviewV1;
 }
 
@@ -71,6 +73,24 @@ export interface WorkflowPreviewValidatorContext {
   readonly currentDependencyRevision: string;
   readonly expectedResourceIds: readonly string[];
   readonly attestation?: ExecutionPlanAttestationV1;
+}
+
+export interface WorkflowDeployValidatorContext {
+  readonly now: string;
+  readonly run: RunConfigV1;
+  readonly provider: "fake" | "bicep" | "terraform";
+  readonly preview: DeploymentPreviewV1;
+  readonly approval: ApprovalEvidenceV1;
+  readonly expectedPreviewHash: string;
+  readonly currentDependencyRevision: string;
+  readonly operation?: OperationRecordV1;
+  readonly attestation?: ExecutionPlanAttestationV1;
+  readonly executionEvidence?: {
+    readonly mode: "native";
+    readonly operationId: string;
+    readonly previewHash: string;
+    readonly validatorIds: readonly string[];
+  };
 }
 
 const VALIDATION_EVIDENCE_IDS = new Set([
@@ -413,7 +433,7 @@ function gateApprovalBindingComplete(value: unknown): ValidationIssue[] {
     approval.previewHash === preview.previewHash &&
     approval.dependencyHash === preview.previewHash &&
     approval.writerEpoch === context.run.ownerEpoch &&
-    approval.recipientIdentity !== undefined &&
+    approval.recipientIdentity === context.currentRecipientIdentity &&
     approval.expiresAt !== undefined &&
     Date.parse(approval.expiresAt) > Date.parse(context.now);
   return valid ? [] : issue("/approval", "Approval does not completely bind the current preview and writer");
@@ -524,6 +544,96 @@ function terraformSavedPlanBinding(value: unknown): ValidationIssue[] {
     attestation.expiresAt === preview.expiresAt &&
     preview.artifactHash === providerArtifactHash;
   return valid ? [] : issue("/attestation", "Terraform saved plan is not bound to the exact preview");
+}
+
+function deployContext(value: unknown): WorkflowDeployValidatorContext {
+  return value as WorkflowDeployValidatorContext;
+}
+
+function deployExactApprovedOperation(value: unknown): ValidationIssue[] {
+  const context = deployContext(value);
+  const preview = context.preview;
+  const approval = context.approval;
+  const { previewHash, ...previewBody } = preview;
+  const valid =
+    sha256Json(previewBody) === previewHash &&
+    context.expectedPreviewHash === previewHash &&
+    approval.projectId === context.run.projectId &&
+    approval.runId === context.run.runId &&
+    approval.gate === 4 &&
+    approval.decision === "approved" &&
+    approval.previewHash === previewHash &&
+    approval.dependencyHash === previewHash &&
+    approval.recipientIdentity !== undefined;
+  return valid ? [] : issue("/approval", "Deployment is not authorized by the exact approved operation");
+}
+
+function deployStaleWriterRejection(value: unknown): ValidationIssue[] {
+  const context = deployContext(value);
+  const preview = context.preview;
+  const approval = context.approval;
+  const now = Date.parse(context.now);
+  const valid =
+    preview.ownerEpoch === context.run.ownerEpoch &&
+    approval.writerEpoch === context.run.ownerEpoch &&
+    preview.commit === context.currentDependencyRevision &&
+    preview.dependencyRevision === context.currentDependencyRevision &&
+    Date.parse(preview.expiresAt) > now &&
+    approval.expiresAt !== undefined &&
+    Date.parse(approval.expiresAt) > now;
+  return valid ? [] : issue("/run", "Deployment writer or dependency authority is stale");
+}
+
+function providerReceiptIncludes(id: string, context: WorkflowDeployValidatorContext): boolean {
+  const operation = context.operation;
+  const evidence = context.executionEvidence;
+  return (
+    operation !== undefined &&
+    operation.state === "succeeded" &&
+    operation.projectId === context.run.projectId &&
+    operation.runId === context.run.runId &&
+    operation.operation === context.preview.operation &&
+    operation.previewHash === context.preview.previewHash &&
+    operation.approvalHash === sha256Json(context.approval) &&
+    operation.ownerEpoch === context.run.ownerEpoch &&
+    evidence?.mode === "native" &&
+    evidence.operationId === operation.operationId &&
+    evidence.previewHash === context.preview.previewHash &&
+    evidence.validatorIds.includes(id)
+  );
+}
+
+function deployBicepStackOwnership(value: unknown): ValidationIssue[] {
+  const context = deployContext(value);
+  return context.provider === "bicep" && providerReceiptIncludes("deploy:bicep-stack-ownership", context)
+    ? []
+    : issue("/executionEvidence", "Native Bicep stack ownership evidence is missing");
+}
+
+function deployExactSavedPlan(value: unknown): ValidationIssue[] {
+  const context = deployContext(value);
+  const attestation = context.attestation;
+  const valid =
+    context.provider === "terraform" &&
+    providerReceiptIncludes("deploy:exact-saved-plan", context) &&
+    attestation !== undefined &&
+    attestation.previewHash === context.preview.previewHash &&
+    attestation.inputHash === context.preview.inputHash &&
+    attestation.iacHash === context.preview.iacHash &&
+    attestation.policyHash === context.preview.policyHash;
+  return valid ? [] : issue("/executionEvidence", "Native Terraform exact saved-plan evidence is missing");
+}
+
+function deployStateLineageAndSerial(value: unknown): ValidationIssue[] {
+  const context = deployContext(value);
+  const attestation = context.attestation;
+  const valid =
+    context.provider === "terraform" &&
+    providerReceiptIncludes("deploy:state-lineage-and-serial", context) &&
+    attestation !== undefined &&
+    attestation.stateLineage === context.preview.stateLineage &&
+    attestation.stateSerial === context.preview.stateSerial;
+  return valid ? [] : issue("/executionEvidence", "Terraform state lineage or serial evidence is missing");
 }
 
 function qualityContext(value: unknown): WorkflowTaskValidatorContext & {
@@ -676,6 +786,12 @@ export function registerWorkflowValidators(registry: ValidatorRegistry): void {
   registry.registerHandler("preview:freshness", previewFreshness, "freshness");
   registry.registerHandler("terraform:saved-plan-binding", terraformSavedPlanBinding, "authorization");
 
+  registry.registerHandler("deploy:exact-approved-operation", deployExactApprovedOperation, "authorization");
+  registry.registerHandler("deploy:stale-writer-rejection", deployStaleWriterRejection, "authorization");
+  registry.registerHandler("deploy:bicep-stack-ownership", deployBicepStackOwnership, "authorization");
+  registry.registerHandler("deploy:exact-saved-plan", deployExactSavedPlan, "authorization");
+  registry.registerHandler("deploy:state-lineage-and-serial", deployStateLineageAndSerial, "authorization");
+
   registry.registerHandler("quality:scorecard-decidable", qualityScorecardDecidable);
   registry.registerHandler("quality:no-subjective-deterministic-claims", qualityNoSubjectiveClaims);
 
@@ -686,6 +802,7 @@ export function registerWorkflowValidators(registry: ValidatorRegistry): void {
     "validation",
     "gate",
     "preview",
+    "deploy",
     "quality",
   ]);
   for (const [id, ownership] of WORKFLOW_VALIDATOR_OWNERSHIP) {

--- a/packages/kernel/src/workflow-validator-ownership.ts
+++ b/packages/kernel/src/workflow-validator-ownership.ts
@@ -129,7 +129,7 @@ const ownershipGroups: readonly OwnershipGroup[] = [
   {
     ids: ["deploy:exact-approved-operation", "deploy:stale-writer-rejection"],
     owner: "@apex/cli",
-    entrypoint: "ApexService.deploy",
+    entrypoint: "ApexService.validateDeployValidators",
     execution: "inline",
     boundary: "deploy",
   },


### PR DESCRIPTION
## Summary
- execute common deploy authorization before any provider side effect
- add native Bicep stack and Terraform exact-plan/state execution receipts
- persist `deployment.executed` immediately after native side effects and reconcile incomplete inventory/post-checks without redeploying
- journal indeterminate provider outcomes and block automatic retry
- label fake deploy evidence simulated with explicit native omissions
- bind Gate 4 approvals and native authority to the current transferred writer
- restore Bicep supersession protection after provider restart

## Validation
- native Bicep/Terraform receipts, extra/missing receipt, reconciliation, idempotent retry, indeterminate failure, and writer-transfer regressions
- full `npm run test:vnext`
- `npm run validate:vnext`
- targeted Prettier and cache-free ESLint
- independent manifest and irreversible-event ordering audit

Tracks #571
Parent #542