### PR TITLE
feat: complete workflow validator enforcement

### DIFF
--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -99,7 +99,9 @@ import {
   type WorkflowGateValidatorContext,
   type WorkflowDeployValidatorContext,
   type WorkflowPreviewValidatorContext,
+  type WorkflowInventoryValidatorContext,
   type WorkflowTaskValidatorContext,
+  type WorkflowTerminalValidatorContext,
 } from "./workflow-validators.js";
 
 const ZERO_HASH = "0".repeat(64);
@@ -570,8 +572,15 @@ export class ApexService {
   }> {
     const selection = await this.selection();
     const run = await this.run(selection);
-    const events = await this.journal(run).replay();
-    const route = await this.route(run, events);
+    let events = await this.journal(run).replay();
+    let route = await this.route(run, events);
+    if (route.task === undefined && route.blockers.length === 0) {
+      const completedEvents = await this.ensureTerminalCompletion(run, events);
+      if (completedEvents !== events) {
+        events = completedEvents;
+        route = await this.route(run, events);
+      }
+    }
     return {
       run,
       head: events.at(-1)?.hash ?? null,
@@ -1346,6 +1355,7 @@ export class ApexService {
             })),
     };
     this.assertValid("inventory", inventory);
+    const inventoryValidatorIds = await this.validateInventoryValidators(run, preview, operation, inventory);
     const inventoryHash = await this.objects.putJson(inventory);
     const omittedValidatorIds = declaredValidatorIds.filter((id) => !commonValidatorIds.includes(id));
     await this.append(run, "deployment.completed", {
@@ -1353,9 +1363,11 @@ export class ApexService {
       inventoryHash,
       previewHash,
       approvalHash,
+      provider: "fake",
       validatorIds: commonValidatorIds,
       preValidatorIds: commonValidatorIds,
       postValidatorIds: [],
+      inventoryValidatorIds,
       ...(omittedValidatorIds.length === 0 ? {} : { omittedValidatorIds }),
       evidenceMode: "simulated",
     });
@@ -1397,9 +1409,11 @@ export class ApexService {
       executionEvidence,
       attestation,
     );
+    const receiptValidatorIds = [...(executionEvidence?.validatorIds ?? [])];
     if (
       executionEvidence === undefined ||
-      JSON.stringify(executionEvidence.validatorIds) !== JSON.stringify(providerValidatorIds)
+      new Set(receiptValidatorIds).size !== receiptValidatorIds.length ||
+      JSON.stringify(receiptValidatorIds.sort()) !== JSON.stringify([...providerValidatorIds].sort())
     ) {
       throw new ApexError(
         "APEX_VALIDATION",
@@ -1410,6 +1424,7 @@ export class ApexService {
     const operationHash = await this.objects.putJson(operation);
     const inventory = await provider.inventory(run.projectId, run.runId);
     this.assertValid("inventory", inventory);
+    const inventoryValidatorIds = await this.validateInventoryValidators(run, preview, operation, inventory);
     const inventoryHash = await this.objects.putJson(inventory);
     const declaredValidatorIds = await this.deployValidatorIds(run);
     await this.append(run, "deployment.completed", {
@@ -1421,6 +1436,7 @@ export class ApexService {
       validatorIds: declaredValidatorIds.filter((id) => [...commonValidatorIds, ...providerValidatorIds].includes(id)),
       preValidatorIds: commonValidatorIds,
       postValidatorIds: providerValidatorIds,
+      inventoryValidatorIds,
       evidenceMode: "native",
     });
     return { operation, inventory };
@@ -2032,6 +2048,12 @@ export class ApexService {
           ? [payload.hash]
           : [];
       }
+      if (event.type === "deployment.completed" && descriptor.id === "diagnosis") {
+        const payload = event.payload as { operationHash?: unknown; inventoryHash?: unknown };
+        return [payload.operationHash, payload.inventoryHash].filter(
+          (hash): hash is string => typeof hash === "string",
+        );
+      }
       return [];
     });
     return [...new Set(hashes)];
@@ -2045,6 +2067,17 @@ export class ApexService {
         return typeof nodeId === "string" ? [nodeId] : [];
       }),
     );
+  }
+
+  private async lockedWorkflowEngine(run: RunConfigV1): Promise<WorkflowEngine> {
+    const runtimeRoot = join(this.root, ".apex", "runtime");
+    const workflowBytes = await readFile(join(runtimeRoot, "workflow.v1.json"));
+    const lock = JSON.parse(await readFile(join(this.root, ".apex", "apex.lock.json"), "utf8")) as RuntimeBundleLockV1;
+    this.assertValid("runtime-lock", lock);
+    if (sha256Json(lock) !== run.runtimeLockHash || sha256Bytes(workflowBytes) !== lock.workflowHash) {
+      throw new ApexError("APEX_STALE", "Runtime workflow lock is not current", EXIT_CODES.stale);
+    }
+    return new WorkflowEngine(JSON.parse(workflowBytes.toString("utf8")));
   }
 
   private async route(
@@ -2065,9 +2098,7 @@ export class ApexService {
       if (!completed.has("plan")) return { task: TASKS.find(({ id }) => id === "plan")!, blockers: [] };
       return { blockers: [] };
     }
-    const manifest = new WorkflowEngine(
-      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
-    ).manifest;
+    const manifest = (await this.lockedWorkflowEngine(run)).manifest;
     const ordered = manifest.nodes
       .flatMap((node) => {
         const descriptor = TASKS.find(({ id }) => id === node.id);
@@ -2163,12 +2194,7 @@ export class ApexService {
   ): Promise<void> {
     if (!this.gateApproved(run, 3))
       throw new ApexError("APEX_AUTHORIZATION", "Gate 3 approval is required before preview", EXIT_CODES.authorization);
-    const runtimeRoot = join(this.root, ".apex", "runtime");
-    const workflowBytes = await readFile(join(runtimeRoot, "workflow.v1.json"));
-    const lock = JSON.parse(await readFile(join(this.root, ".apex", "apex.lock.json"), "utf8")) as RuntimeBundleLockV1;
-    if (sha256Json(lock) !== run.runtimeLockHash || sha256Bytes(workflowBytes) !== lock.workflowHash)
-      throw new ApexError("APEX_STALE", "Runtime workflow lock is not current", EXIT_CODES.stale);
-    const engine = new WorkflowEngine(JSON.parse(workflowBytes.toString("utf8")));
+    const engine = await this.lockedWorkflowEngine(run);
     const aliases: Partial<Record<ArtifactKind, string>> = {
       requirements: "requirements-v1",
       "sku-manifest": "sku-manifest-v1",
@@ -2396,9 +2422,7 @@ export class ApexService {
     outputs: TaskOutput[],
     events: Awaited<ReturnType<EventJournal["replay"]>>,
   ): Promise<WorkflowValidationExecution> {
-    const workflow = new WorkflowEngine(
-      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
-    );
+    const workflow = await this.lockedWorkflowEngine(run);
     const nodeId = descriptor.reviewSubject ?? descriptor.id;
     const node = workflow.manifest.nodes.find(({ id }) => id === nodeId);
     if (node === undefined) throw new Error(`Workflow task ${nodeId} has no manifest node`);
@@ -2409,7 +2433,9 @@ export class ApexService {
           ? "validation"
           : descriptor.id === "quality"
             ? "quality"
-            : "task-output";
+            : descriptor.id === "diagnosis"
+              ? "diagnosis"
+              : "task-output";
     const boundaries = new Set([boundary, ...(descriptor.id === "architecture" ? ["external-evidence"] : [])]);
     const validatorIds = node.validators.filter((id) => {
       const validatorBoundary = workflowValidatorOwnership(id)?.boundary;
@@ -2428,6 +2454,8 @@ export class ApexService {
     );
     let availabilityEvidence: ArchitectureAvailabilityV1 | undefined;
     let availabilityHash: string | undefined;
+    let deploymentOperation: OperationRecordV1 | undefined;
+    let deploymentInventory: ResourceInventoryV1 | undefined;
     if (descriptor.id === "architecture") {
       const pinnedRefs = new Set(task.inputRefs);
       availabilityHash = this.latestPayloadHash(
@@ -2445,6 +2473,21 @@ export class ApexService {
         this.assertValid("architecture-availability", availabilityEvidence);
       }
     }
+    if (descriptor.id === "diagnosis") {
+      const completed = [...events].reverse().find((event) => event.type === "deployment.completed");
+      const payload = completed?.payload as { operationHash?: unknown; inventoryHash?: unknown } | undefined;
+      if (
+        typeof payload?.operationHash === "string" &&
+        typeof payload.inventoryHash === "string" &&
+        task.inputRefs.includes(payload.operationHash) &&
+        task.inputRefs.includes(payload.inventoryHash)
+      ) {
+        deploymentOperation = await this.objects.getJson<OperationRecordV1>(payload.operationHash);
+        deploymentInventory = await this.objects.getJson<ResourceInventoryV1>(payload.inventoryHash);
+        this.assertValid("operation", deploymentOperation);
+        this.assertValid("inventory", deploymentInventory);
+      }
+    }
     const context: WorkflowTaskValidatorContext = {
       nodeId,
       now: this.clock().toISOString(),
@@ -2455,6 +2498,8 @@ export class ApexService {
       artifacts,
       artifactHashes,
       ...(availabilityEvidence === undefined ? {} : { availabilityEvidence }),
+      ...(deploymentOperation === undefined ? {} : { deploymentOperation }),
+      ...(deploymentInventory === undefined ? {} : { deploymentInventory }),
       ...(nodeId === "quality" ? await this.qualityValidatorContext() : {}),
     };
     for (const id of validatorIds) {
@@ -2502,9 +2547,7 @@ export class ApexService {
     events: Awaited<ReturnType<EventJournal["replay"]>>,
     approval: ApprovalEvidenceV1,
   ): Promise<string[]> {
-    const workflow = new WorkflowEngine(
-      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
-    );
+    const workflow = await this.lockedWorkflowEngine(run);
     const nodeId = `gate-${gate.gate}`;
     const node = workflow.manifest.nodes.find(({ id }) => id === nodeId);
     if (node === undefined) throw new Error(`Workflow gate ${nodeId} has no manifest node`);
@@ -2586,9 +2629,7 @@ export class ApexService {
     intent: ImplementationIntentV1,
     attestation?: ExecutionPlanAttestationV1,
   ): Promise<{ validatorIds: string[]; omittedValidatorIds: string[]; evidenceMode: "native" | "simulated" }> {
-    const workflow = new WorkflowEngine(
-      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
-    );
+    const workflow = await this.lockedWorkflowEngine(run);
     const nodeId = `preview-${run.iacTool}`;
     const node = workflow.manifest.nodes.find(({ id }) => id === nodeId);
     if (node === undefined) throw new Error(`Workflow preview ${nodeId} has no manifest node`);
@@ -2629,9 +2670,7 @@ export class ApexService {
     executionEvidence?: ProviderExecutionEvidence,
     attestation?: ExecutionPlanAttestationV1,
   ): Promise<string[]> {
-    const workflow = new WorkflowEngine(
-      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
-    );
+    const workflow = await this.lockedWorkflowEngine(run);
     const nodeId = `deploy-${run.iacTool}`;
     const node = workflow.manifest.nodes.find(({ id }) => id === nodeId);
     if (node === undefined) throw new Error(`Workflow deployment ${nodeId} has no manifest node`);
@@ -2657,14 +2696,144 @@ export class ApexService {
   }
 
   private async deployValidatorIds(run: RunConfigV1): Promise<string[]> {
-    const workflow = new WorkflowEngine(
-      JSON.parse(await readFile(join(this.root, ".apex", "runtime", "workflow.v1.json"), "utf8")),
-    );
+    const workflow = await this.lockedWorkflowEngine(run);
     return (
       workflow.manifest.nodes
         .find(({ id }) => id === `deploy-${run.iacTool}`)
         ?.validators.filter((id) => workflowValidatorOwnership(id)?.boundary === "deploy") ?? []
     );
+  }
+
+  private async validateInventoryValidators(
+    run: RunConfigV1,
+    preview: DeploymentPreviewV1,
+    operation: OperationRecordV1,
+    inventory: ResourceInventoryV1,
+  ): Promise<string[]> {
+    const workflow = await this.lockedWorkflowEngine(run);
+    const node = workflow.manifest.nodes.find(({ id }) => id === "inventory");
+    if (node === undefined) throw new Error("Workflow inventory node is missing");
+    const validatorIds = node.validators.filter((id) => workflowValidatorOwnership(id)?.boundary === "inventory");
+    const context: WorkflowInventoryValidatorContext = { run, preview, operation, inventory };
+    for (const id of validatorIds) this.assertValid(id, context);
+    return validatorIds;
+  }
+
+  private async ensureTerminalCompletion(
+    run: RunConfigV1,
+    events: Awaited<ReturnType<EventJournal["replay"]>>,
+  ): Promise<Awaited<ReturnType<EventJournal["replay"]>>> {
+    if (events.some(({ type }) => type === "workflow.completed")) return events;
+    const workflow = await this.lockedWorkflowEngine(run);
+    const legacy = events.some(
+      (event) => event.type === "task.completed" && (event.payload as { legacy?: unknown }).legacy === true,
+    );
+    const artifactAliases: Readonly<Record<string, string>> = {
+      requirements: "requirements-v1",
+      "sku-manifest": "sku-manifest-v1",
+      architecture: "architecture-v1",
+      "cost-estimate": "cost-estimate-v1",
+      "governance-constraints": "governance-constraints-v1",
+      "policy-property-map": "policy-property-map-v1",
+      "implementation-intent": "implementation-intent-v1",
+      "iac-binding": "iac-binding-v1",
+      "environment-inputs": "environment-inputs-v1",
+      "logical-resource-manifest": "logical-resource-manifest-v1",
+      "iac-handoff": "iac-handoff-v1",
+      "validation-evidence": "validation-evidence-v1",
+      diagnosis: "diagnosis-report-v1",
+      "quality-report": "quality-report-v1",
+    };
+    const artifacts: Record<string, JsonValue> = {};
+    for (const event of events) {
+      const payload = event.payload as Record<string, unknown>;
+      if (event.type === "task.completed") {
+        const hashes = (payload.artifactHashes as Record<string, unknown> | undefined) ?? {};
+        for (const [kind, hash] of Object.entries(hashes)) {
+          if (typeof hash === "string") artifacts[artifactAliases[kind] ?? kind] = hash;
+        }
+      }
+      if (event.type === "preview.created" && typeof payload.previewHash === "string") {
+        artifacts["deployment-preview-v1"] = payload.previewHash;
+      }
+      if (event.type === "gate.decided" && payload.gate === 4 && typeof payload.approvalHash === "string") {
+        artifacts["approval-evidence-v1"] = payload.approvalHash;
+      }
+      if (event.type === "deployment.completed") {
+        if (typeof payload.operationHash === "string") artifacts["operation-record-v1"] = payload.operationHash;
+        if (typeof payload.inventoryHash === "string") artifacts["resource-inventory-v1"] = payload.inventoryHash;
+      }
+    }
+    const activeValidatorIds = legacy
+      ? events.flatMap((event) => {
+          if (event.type !== "task.completed") return [];
+          const ids = (event.payload as { validatorIds?: unknown }).validatorIds;
+          return Array.isArray(ids) ? ids.filter((id): id is string => typeof id === "string") : [];
+        })
+      : workflow.activeValidatorIds({
+          run: { iacTool: run.iacTool, targetScope: run.targetScope },
+          artifacts,
+        });
+    const executedValidatorIds = new Set<string>();
+    const simulatedOmittedValidatorIds = new Set<string>();
+    for (const event of events) {
+      const payload = event.payload as {
+        validatorIds?: unknown;
+        inventoryValidatorIds?: unknown;
+        omittedValidatorIds?: unknown;
+        evidenceMode?: unknown;
+        provider?: unknown;
+      };
+      for (const ids of [payload.validatorIds, payload.inventoryValidatorIds]) {
+        if (Array.isArray(ids)) {
+          for (const id of ids) if (typeof id === "string") executedValidatorIds.add(id);
+        }
+      }
+      const omissionNodeId =
+        payload.evidenceMode === "simulated" && payload.provider === "fake"
+          ? event.type === "preview.created"
+            ? `preview-${run.iacTool}`
+            : event.type === "deployment.completed"
+              ? `deploy-${run.iacTool}`
+              : undefined
+          : undefined;
+      const allowedOmissions = new Set(
+        workflow.manifest.nodes
+          .find(({ id }) => id === omissionNodeId)
+          ?.validators.filter((id) => workflowValidatorOwnership(id)?.owner === "@apex/capabilities") ?? [],
+      );
+      if (Array.isArray(payload.omittedValidatorIds)) {
+        for (const id of payload.omittedValidatorIds) {
+          if (typeof id === "string" && allowedOmissions.has(id)) simulatedOmittedValidatorIds.add(id);
+        }
+      }
+    }
+    for (const gate of run.gates) {
+      if (gate.state !== "inherited") continue;
+      const node = workflow.manifest.nodes.find(({ id }) => id === `gate-${gate.gate}`);
+      for (const id of node?.validators ?? []) {
+        if (workflowValidatorOwnership(id)?.boundary === "gate") executedValidatorIds.add(id);
+      }
+    }
+    const terminalIds =
+      workflow.manifest.nodes
+        .find(({ id }) => id === "completed")
+        ?.validators.filter((id) => workflowValidatorOwnership(id)?.boundary === "terminal") ?? [];
+    const deduplicatedActiveValidatorIds = [...new Set(activeValidatorIds)].sort();
+    const context: WorkflowTerminalValidatorContext = {
+      activeValidatorIds: deduplicatedActiveValidatorIds,
+      executedValidatorIds: [...executedValidatorIds].sort(),
+      simulatedOmittedValidatorIds: [...simulatedOmittedValidatorIds].sort(),
+    };
+    for (const id of terminalIds) this.assertValid(id, context);
+    await this.append(run, "workflow.completed", {
+      validatorIds: terminalIds,
+      activeValidatorIds: deduplicatedActiveValidatorIds,
+      executedValidatorIds: [...context.executedValidatorIds],
+      simulatedOmittedValidatorIds: [...context.simulatedOmittedValidatorIds],
+      ...(legacy ? { legacy: true } : {}),
+    });
+    return this.journal(run).replay();
   }
 
   private initialSkuManifest(run: RunConfigV1, requirements: unknown): unknown {

--- a/packages/cli/src/test/expanded-workflow.test.ts
+++ b/packages/cli/src/test/expanded-workflow.test.ts
@@ -12,10 +12,11 @@ import type {
   LogicalResourceManifestV1,
 } from "@apex/contracts";
 import type { IacProvider, PreviewRequest } from "@apex/capabilities";
-import { EventJournal, sha256Json } from "@apex/kernel";
+import { EventJournal, ValidatorRegistry, sha256Json } from "@apex/kernel";
 import { ApexError } from "../errors.js";
 import { createMcpServer } from "../mcp.js";
 import { ApexService, type TaskOutput } from "../service.js";
+import { registerWorkflowValidators } from "../workflow-validators.js";
 import {
   architecture,
   acceptAvailabilityEvidence,
@@ -118,7 +119,15 @@ async function reachValidation(service: ApexService, runId: string, track: "bice
 function terraformPreviewProvider(
   now: Date,
   mutation?:
-    "input-hash" | "operation" | "state" | "apply-error" | "missing-receipt" | "extra-receipt" | "inventory-once",
+    | "input-hash"
+    | "operation"
+    | "state"
+    | "apply-error"
+    | "missing-receipt"
+    | "extra-receipt"
+    | "inventory-once"
+    | "secret-inventory"
+    | "incomplete-inventory",
 ): IacProvider & {
   attestation(previewHash: string): ExecutionPlanAttestationV1 | undefined;
 } {
@@ -126,6 +135,7 @@ function terraformPreviewProvider(
   let executionEvidence:
     { mode: "native"; operationId: string; previewHash: string; validatorIds: string[] } | undefined;
   let inventoryCalls = 0;
+  let latestPreview: DeploymentPreviewV1 | undefined;
   const createPreview = async (request: PreviewRequest): Promise<DeploymentPreviewV1> => {
     const plan = {
       planDigest: "1".repeat(64),
@@ -157,6 +167,7 @@ function terraformPreviewProvider(
       expiresAt: new Date(now.getTime() + request.ttlMs).toISOString(),
     };
     const preview = { ...base, previewHash: sha256Json(base) };
+    latestPreview = preview;
     attestation = {
       schemaVersion: "1.0.0",
       projectId: request.projectId,
@@ -233,7 +244,17 @@ function terraformPreviewProvider(
         runId,
         deploymentHash: "9".repeat(64),
         collectedAt: now.toISOString(),
-        resources: [],
+        resources:
+          mutation === "incomplete-inventory"
+            ? []
+            : (latestPreview?.changes ?? []).map(({ resourceId }) => ({
+                logicalId: resourceId,
+                resourceId,
+                type: "terraform/resource",
+                location: "terraform-managed",
+                properties:
+                  mutation === "secret-inventory" ? { token: "Bearer secret-token-value" } : { provider: "terraform" },
+              })),
       };
     },
     reconcile: async () => undefined,
@@ -246,6 +267,7 @@ function terraformPreviewProvider(
 function bicepPreviewProvider(now: Date): IacProvider {
   let executionEvidence:
     { mode: "native"; operationId: string; previewHash: string; validatorIds: string[] } | undefined;
+  let latestPreview: DeploymentPreviewV1 | undefined;
   const createPreview = async (request: PreviewRequest): Promise<DeploymentPreviewV1> => {
     const base = {
       schemaVersion: "1.0.0" as const,
@@ -267,7 +289,8 @@ function bicepPreviewProvider(now: Date): IacProvider {
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + request.ttlMs).toISOString(),
     };
-    return { ...base, previewHash: sha256Json(base) };
+    latestPreview = { ...base, previewHash: sha256Json(base) };
+    return latestPreview;
   };
   return {
     track: "bicep",
@@ -305,7 +328,13 @@ function bicepPreviewProvider(now: Date): IacProvider {
       runId,
       deploymentHash: "7".repeat(64),
       collectedAt: now.toISOString(),
-      resources: [],
+      resources: (latestPreview?.changes ?? []).map(({ resourceId }) => ({
+        logicalId: resourceId,
+        resourceId,
+        type: "bicep/resource",
+        location: "swedencentral",
+        properties: { provider: "bicep" },
+      })),
     }),
     reconcile: async () => undefined,
     executionEvidence: (operationId) =>
@@ -333,6 +362,26 @@ test("task completion records executed manifest validators in order", async () =
   ]);
 });
 
+test("task validation refuses workflow bytes outside the run lock", async () => {
+  const root = await tempRoot();
+  const service = new ApexService(root);
+  await service.init({ projectId: "demo" });
+  await service.nextTask();
+  const issued = await service.nextTask();
+  assert.equal(issued.status, "task");
+  if (issued.status !== "task") return;
+  const workflowPath = join(root, ".apex", "runtime", "workflow.v1.json");
+  const workflowBytes = await readFile(workflowPath);
+  await writeFile(workflowPath, Buffer.concat([workflowBytes, Buffer.from("\n")]));
+  await assert.rejects(
+    service.completeTaskOutputs(issued.task.taskId, [
+      { kind: "requirements", value: requirements() },
+      { kind: "sku-manifest", value: skuManifest(sha256Json(requirements())) },
+    ]),
+    (error: unknown) => error instanceof ApexError && error.code === "APEX_STALE",
+  );
+});
+
 test("gate approval records executed manifest validators in order", async () => {
   const root = await tempRoot();
   const service = new ApexService(root);
@@ -348,6 +397,14 @@ test("gate approval records executed manifest validators in order", async () => 
       value: review(runId, "requirements", requirementHashes.requirements!),
     },
   ]);
+  const workflowPath = join(root, ".apex", "runtime", "workflow.v1.json");
+  const workflowBytes = await readFile(workflowPath);
+  await writeFile(workflowPath, Buffer.concat([workflowBytes, Buffer.from("\n")]));
+  await assert.rejects(
+    service.decideGateNumber(1, "approved", "tester"),
+    (error: unknown) => error instanceof ApexError && error.code === "APEX_STALE",
+  );
+  await writeFile(workflowPath, workflowBytes);
   await service.decideGateNumber(1, "approved", "tester");
 
   const events = await new EventJournal(join(root, ".apex", "projects", "demo", "runs", runId, "journal")).replay();
@@ -695,20 +752,53 @@ for (const track of ["bicep", "terraform"] as const) {
         : ["deploy:exact-saved-plan", "deploy:state-lineage-and-serial"],
     );
     assert.equal((deployment?.payload as { evidenceMode?: unknown }).evidenceMode, "simulated");
-    await complete(service, "diagnosis", [
-      {
-        kind: "diagnosis",
-        value: {
-          schemaVersion: "1.0.0",
-          projectId: "demo",
-          runId,
-          diagnosedAt: "2026-01-01T00:00:00.000Z",
-          status: "healthy",
-          observations: ["deployed"],
-          causes: [],
-        },
-      },
+    assert.deepEqual((deployment?.payload as { inventoryValidatorIds?: unknown }).inventoryValidatorIds, [
+      "inventory:secret-free",
+      "inventory:source-coverage",
+      "inventory:eventual-consistency-reconciled",
     ]);
+    const diagnosisTask = await task(service, "diagnosis");
+    const diagnosis = {
+      schemaVersion: "1.0.0" as const,
+      projectId: "demo",
+      runId,
+      diagnosedAt: deployed.inventory.collectedAt,
+      status: "healthy" as const,
+      observations: ["deployed"],
+      causes: [],
+    };
+    await assert.rejects(
+      service.completeTaskOutputs(diagnosisTask, [
+        { kind: "diagnosis", value: { ...diagnosis, observations: ["Bearer secret-token-value"] } },
+      ]),
+      /diagnosis:secret-free/,
+    );
+    await assert.rejects(
+      service.completeTaskOutputs(diagnosisTask, [
+        { kind: "diagnosis", value: { ...diagnosis, diagnosedAt: "2099-01-01T00:00:00.000Z" } },
+      ]),
+      /diagnosis:read-only/,
+    );
+    await assert.rejects(
+      service.completeTaskOutputs(diagnosisTask, [
+        {
+          kind: "diagnosis",
+          value: {
+            ...diagnosis,
+            causes: [
+              {
+                id: "cause-1",
+                summary: "Observed mismatch",
+                confidence: "medium",
+                evidenceRefs: ["e".repeat(64)],
+              },
+            ],
+          },
+        },
+      ]),
+      /diagnosis:read-only/,
+    );
+    await service.completeTaskOutputs(diagnosisTask, [{ kind: "diagnosis", value: diagnosis }]);
     const qualityTask = await task(service, "quality");
     const report = await qualityReport(root, runId);
     const staleScorecard = { ...report, scorecardHash: "f".repeat(64) };
@@ -773,7 +863,54 @@ for (const track of ["bicep", "terraform"] as const) {
       "quality:scorecard-decidable",
       "quality:no-subjective-deterministic-claims",
     ]);
+    if (track === "bicep") {
+      const workflowPath = join(root, ".apex", "runtime", "workflow.v1.json");
+      const workflowBytes = await readFile(workflowPath);
+      await writeFile(workflowPath, Buffer.concat([workflowBytes, Buffer.from("\n")]));
+      await assert.rejects(
+        service.status(),
+        (error: unknown) => error instanceof ApexError && error.code === "APEX_STALE",
+      );
+      await writeFile(workflowPath, workflowBytes);
+    }
     assert.equal((await service.status()).task, null);
+    assert.equal((await service.status()).task, null);
+    const finalEvents = await new EventJournal(
+      join(root, ".apex", "projects", "demo", "runs", runId, "journal"),
+    ).replay();
+    const diagnosisCompleted = [...finalEvents]
+      .reverse()
+      .find(
+        (event) => event.type === "task.completed" && (event.payload as { nodeId?: unknown }).nodeId === "diagnosis",
+      );
+    assert.deepEqual((diagnosisCompleted?.payload as { validatorIds?: unknown }).validatorIds, [
+      "diagnosis:read-only",
+      "diagnosis:secret-free",
+    ]);
+    const workflowCompleted = [...finalEvents].reverse().find((event) => event.type === "workflow.completed");
+    assert.deepEqual((workflowCompleted?.payload as { validatorIds?: unknown }).validatorIds, [
+      "terminal:run-evidence-complete",
+    ]);
+    const terminalPayload = workflowCompleted?.payload as {
+      activeValidatorIds?: string[];
+      executedValidatorIds?: string[];
+      simulatedOmittedValidatorIds?: string[];
+    };
+    const accounted = new Set([
+      ...(terminalPayload.executedValidatorIds ?? []),
+      ...(terminalPayload.simulatedOmittedValidatorIds ?? []),
+    ]);
+    assert.equal(
+      (terminalPayload.activeValidatorIds ?? [])
+        .filter((id) => id !== "terminal:run-evidence-complete")
+        .every((id) => accounted.has(id)),
+      true,
+    );
+    const trackValidator = track === "bicep" ? "bicep:build" : "terraform:validate";
+    const opposingTrackValidator = track === "bicep" ? "terraform:validate" : "bicep:build";
+    assert.equal((terminalPayload.activeValidatorIds ?? []).includes(trackValidator), true);
+    assert.equal((terminalPayload.activeValidatorIds ?? []).includes(opposingTrackValidator), false);
+    assert.equal(finalEvents.filter(({ type }) => type === "workflow.completed").length, 1);
   });
 }
 
@@ -924,6 +1061,33 @@ test("native Terraform preview records saved-plan validation and rejects wrong b
     false,
   );
 
+  for (const mutation of ["secret-inventory", "incomplete-inventory"] as const) {
+    const inventoryRoot = await tempRoot();
+    const inventoryService = new ApexService(inventoryRoot, {
+      clock: () => now,
+      providers: { terraform: terraformPreviewProvider(now, mutation) },
+    });
+    const inventoryRun = await inventoryService.init({ projectId: "demo", iacTool: "terraform" });
+    await reachValidation(inventoryService, inventoryRun.runId, "terraform");
+    const inventoryPreview = await inventoryService.preview({ operation: "apply", provider: "terraform" });
+    await inventoryService.decideGateNumber(4, "approved", "tester");
+    await assert.rejects(
+      inventoryService.deploy(inventoryPreview.previewHash),
+      mutation === "secret-inventory" ? /inventory:secret-free/ : /inventory:source-coverage/,
+    );
+    const inventoryEvents = await new EventJournal(
+      join(inventoryRoot, ".apex", "projects", "demo", "runs", inventoryRun.runId, "journal"),
+    ).replay();
+    assert.equal(
+      inventoryEvents.some(({ type }) => type === "deployment.executed"),
+      true,
+    );
+    assert.equal(
+      inventoryEvents.some(({ type }) => type === "deployment.completed"),
+      false,
+    );
+  }
+
   const invalidRoot = await tempRoot();
   const invalid = new ApexService(invalidRoot, {
     clock: () => now,
@@ -972,6 +1136,18 @@ test("native Terraform preview records saved-plan validation and rejects wrong b
   });
   await recovering.preview({ operation: "apply", provider: "terraform" });
   assert.equal((await recovering.status()).run.gates[3]?.state, "open");
+});
+
+test("terminal validator rejects unaccounted active validators", () => {
+  const registry = new ValidatorRegistry();
+  registerWorkflowValidators(registry);
+  const result = registry.validate("terminal:run-evidence-complete", {
+    activeValidatorIds: ["schema:requirements-v1", "terminal:run-evidence-complete"],
+    executedValidatorIds: [],
+    simulatedOmittedValidatorIds: [],
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.issues[0]?.message ?? "", /schema:requirements-v1/);
 });
 
 test("review blockers persist, resolve, and permit gate approval", async () => {

--- a/packages/cli/src/workflow-validators.ts
+++ b/packages/cli/src/workflow-validators.ts
@@ -10,6 +10,7 @@ import {
   type ArchitectureAvailabilityV1,
   type ArchitectureV1,
   type CostEstimateV1,
+  type DiagnosisV1,
   type EvidenceManifestV1,
   type ExecutionPlanAttestationV1,
   type GateRecordV1,
@@ -24,6 +25,7 @@ import {
   type QualityScorecardV1,
   type RequirementsV1,
   type ReviewFindingsV1,
+  type ResourceInventoryV1,
   type RunConfigV1,
   type DeploymentPreviewV1,
 } from "@apex/contracts";
@@ -42,6 +44,8 @@ export interface WorkflowTaskValidatorContext {
   readonly scorecard?: QualityScorecardV1;
   readonly qualityMeasurements?: QualityMeasurementsV1;
   readonly availabilityEvidence?: ArchitectureAvailabilityV1;
+  readonly deploymentOperation?: OperationRecordV1;
+  readonly deploymentInventory?: ResourceInventoryV1;
 }
 
 export interface WorkflowGateValidatorContext {
@@ -93,6 +97,19 @@ export interface WorkflowDeployValidatorContext {
   };
 }
 
+export interface WorkflowInventoryValidatorContext {
+  readonly run: RunConfigV1;
+  readonly preview: DeploymentPreviewV1;
+  readonly operation: OperationRecordV1;
+  readonly inventory: ResourceInventoryV1;
+}
+
+export interface WorkflowTerminalValidatorContext {
+  readonly activeValidatorIds: readonly string[];
+  readonly executedValidatorIds: readonly string[];
+  readonly simulatedOmittedValidatorIds: readonly string[];
+}
+
 const VALIDATION_EVIDENCE_IDS = new Set([
   "bicep:build",
   "bicep:format",
@@ -107,6 +124,26 @@ const VALIDATION_EVIDENCE_IDS = new Set([
 
 function issue(path: string, message: string): ValidationIssue[] {
   return [{ path, message }];
+}
+
+const SECRET_FIELD =
+  /(?:secret|password|passphrase|token|authorization|api[-_]?key|private[-_]?key|connectionString|sasToken)/i;
+const SECRET_VALUE =
+  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|\bBearer\s+[A-Za-z0-9._~+\/-]{16,}|(?:AccountKey|SharedAccessSignature)=/i;
+
+function secretIssues(value: unknown, path = ""): ValidationIssue[] {
+  if (Array.isArray(value)) return value.flatMap((item, index) => secretIssues(item, `${path}/${index}`));
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .flatMap(([key, item]) => [
+        ...(SECRET_FIELD.test(key) ? [{ path: `${path}/${key}`, message: "Secret-bearing field is not allowed" }] : []),
+        ...secretIssues(item, `${path}/${key}`),
+      ]);
+  }
+  return typeof value === "string" && SECRET_VALUE.test(value)
+    ? [{ path, message: "Secret-bearing value is not allowed" }]
+    : [];
 }
 
 function taskContext(value: unknown): WorkflowTaskValidatorContext {
@@ -636,6 +673,106 @@ function deployStateLineageAndSerial(value: unknown): ValidationIssue[] {
   return valid ? [] : issue("/executionEvidence", "Terraform state lineage or serial evidence is missing");
 }
 
+function inventoryContext(value: unknown): WorkflowInventoryValidatorContext {
+  return value as WorkflowInventoryValidatorContext;
+}
+
+function inventorySecretFree(value: unknown): ValidationIssue[] {
+  return secretIssues(inventoryContext(value).inventory, "/inventory");
+}
+
+function inventorySourceCoverage(value: unknown): ValidationIssue[] {
+  const context = inventoryContext(value);
+  const inventory = context.inventory;
+  const resourceIds = inventory.resources.map(({ resourceId }) => resourceId);
+  const logicalIds = inventory.resources.map(({ logicalId }) => logicalId);
+  const issues: ValidationIssue[] = [];
+  if (new Set(resourceIds).size !== resourceIds.length || new Set(logicalIds).size !== logicalIds.length) {
+    issues.push({ path: "/inventory/resources", message: "Inventory resource identities must be unique" });
+  }
+  const expected = context.preview.changes
+    .filter(({ material, action }) => material && action !== "delete" && action !== "no-op")
+    .map(({ resourceId }) => resourceId);
+  const missing = expected.filter(
+    (expectedId) =>
+      !inventory.resources.some(
+        ({ logicalId, resourceId }) =>
+          logicalId === expectedId || resourceId === expectedId || resourceId.endsWith(`:${expectedId}`),
+      ),
+  );
+  if (missing.length > 0) {
+    issues.push({
+      path: "/inventory/resources",
+      message: `Inventory is missing preview resources: ${missing.sort().join(", ")}`,
+    });
+  }
+  return issues;
+}
+
+function inventoryEventuallyReconciled(value: unknown): ValidationIssue[] {
+  const context = inventoryContext(value);
+  const inventory = context.inventory;
+  const operation = context.operation;
+  const valid =
+    operation.state === "succeeded" &&
+    operation.projectId === context.run.projectId &&
+    operation.runId === context.run.runId &&
+    operation.previewHash === context.preview.previewHash &&
+    inventory.projectId === context.run.projectId &&
+    inventory.runId === context.run.runId &&
+    Date.parse(inventory.collectedAt) >= Date.parse(operation.updatedAt) &&
+    (context.preview.operation !== "destroy" || inventory.resources.length === 0);
+  return valid ? [] : issue("/inventory", "Inventory does not reconcile the completed operation");
+}
+
+function diagnosisReadOnly(value: unknown): ValidationIssue[] {
+  const context = taskContext(value);
+  const diagnosis = context.outputs.diagnosis as DiagnosisV1;
+  const operation = context.deploymentOperation;
+  const inventory = context.deploymentInventory;
+  if (operation === undefined || inventory === undefined) {
+    return issue("/deployment", "Accepted operation and inventory are required for diagnosis");
+  }
+  const issues: ValidationIssue[] = [];
+  if (
+    diagnosis.projectId !== operation.projectId ||
+    diagnosis.runId !== operation.runId ||
+    Date.parse(diagnosis.diagnosedAt) < Date.parse(inventory.collectedAt) ||
+    Date.parse(diagnosis.diagnosedAt) > Date.parse(context.now)
+  ) {
+    issues.push({
+      path: "/outputs/diagnosis",
+      message: "Diagnosis is not a read-only observation of current inventory",
+    });
+  }
+  const unpinned = diagnosis.causes
+    .flatMap(({ evidenceRefs }) => evidenceRefs)
+    .filter((reference) => !context.inputRefs.includes(reference))
+    .sort();
+  if (unpinned.length > 0) {
+    issues.push({
+      path: "/outputs/diagnosis/causes",
+      message: `Diagnosis evidence was not pinned to the task: ${unpinned.join(", ")}`,
+    });
+  }
+  return issues;
+}
+
+function diagnosisSecretFree(value: unknown): ValidationIssue[] {
+  return secretIssues(taskContext(value).outputs.diagnosis, "/outputs/diagnosis");
+}
+
+function terminalRunEvidenceComplete(value: unknown): ValidationIssue[] {
+  const context = value as WorkflowTerminalValidatorContext;
+  const accounted = new Set([...context.executedValidatorIds, ...context.simulatedOmittedValidatorIds]);
+  const missing = [...new Set(context.activeValidatorIds)]
+    .filter((id) => id !== "terminal:run-evidence-complete" && !accounted.has(id))
+    .sort();
+  return missing.length === 0
+    ? []
+    : issue("/validatorEvidence", `Run is missing validator evidence: ${missing.join(", ")}`);
+}
+
 function qualityContext(value: unknown): WorkflowTaskValidatorContext & {
   readonly scorecard: QualityScorecardV1;
   readonly qualityMeasurements: QualityMeasurementsV1;
@@ -792,8 +929,17 @@ export function registerWorkflowValidators(registry: ValidatorRegistry): void {
   registry.registerHandler("deploy:exact-saved-plan", deployExactSavedPlan, "authorization");
   registry.registerHandler("deploy:state-lineage-and-serial", deployStateLineageAndSerial, "authorization");
 
+  registry.registerHandler("inventory:secret-free", inventorySecretFree);
+  registry.registerHandler("inventory:source-coverage", inventorySourceCoverage);
+  registry.registerHandler("inventory:eventual-consistency-reconciled", inventoryEventuallyReconciled, "freshness");
+
+  registry.registerHandler("diagnosis:read-only", diagnosisReadOnly);
+  registry.registerHandler("diagnosis:secret-free", diagnosisSecretFree);
+
   registry.registerHandler("quality:scorecard-decidable", qualityScorecardDecidable);
   registry.registerHandler("quality:no-subjective-deterministic-claims", qualityNoSubjectiveClaims);
+
+  registry.registerHandler("terminal:run-evidence-complete", terminalRunEvidenceComplete, "authorization");
 
   const requiredBoundaries = new Set([
     "task-output",
@@ -803,7 +949,10 @@ export function registerWorkflowValidators(registry: ValidatorRegistry): void {
     "gate",
     "preview",
     "deploy",
+    "inventory",
+    "diagnosis",
     "quality",
+    "terminal",
   ]);
   for (const [id, ownership] of WORKFLOW_VALIDATOR_OWNERSHIP) {
     if (requiredBoundaries.has(ownership.boundary) && !registry.has(id)) {

--- a/packages/kernel/src/test/workflow-engine.test.ts
+++ b/packages/kernel/src/test/workflow-engine.test.ts
@@ -51,6 +51,9 @@ test("workflow manifest validates and routes both tracks deterministically", () 
     gateStates: { "gate-1": "approved" },
   });
   assert.equal(discovery.nextTask, "governance-discovery");
+  const bicepValidators = engine.activeValidatorIds({ run: { iacTool: "bicep" }, artifacts: {} });
+  assert.ok(bicepValidators.includes("bicep:build"));
+  assert.equal(bicepValidators.includes("terraform:validate"), false);
 });
 
 test("workflow rejects unknown operators, cycles, duplicate gates, and missing tracks", () => {

--- a/packages/kernel/src/workflow-engine.ts
+++ b/packages/kernel/src/workflow-engine.ts
@@ -85,7 +85,6 @@ export class WorkflowEngine {
         terminal: false,
       };
     }
-
     const completed = new Set(state.completedNodes ?? []);
     for (const node of this.manifest.nodes) {
       if (node.kind === "terminal" || completed.has(node.id) || !evaluateCondition(node.condition, state)) {
@@ -109,6 +108,12 @@ export class WorkflowEngine {
       }
     }
     return { currentNode: null, nextTask: null, ownerRole: null, blockers: ["no-eligible-node"], terminal: false };
+  }
+
+  activeValidatorIds(state: WorkflowState): string[] {
+    return this.manifest.nodes
+      .filter((node) => evaluateCondition(node.condition, state))
+      .flatMap(({ validators }) => validators);
   }
 
   invalidationPlan(changedNodeId: string, reason: string): InvalidationEntry[] {

--- a/packages/kernel/src/workflow-validator-ownership.ts
+++ b/packages/kernel/src/workflow-validator-ownership.ts
@@ -150,14 +150,14 @@ const ownershipGroups: readonly OwnershipGroup[] = [
   {
     ids: ["inventory:eventual-consistency-reconciled", "inventory:secret-free", "inventory:source-coverage"],
     owner: "@apex/cli",
-    entrypoint: "ApexService.inventory",
+    entrypoint: "ApexService.validateInventoryValidators",
     execution: "inline",
     boundary: "inventory",
   },
   {
     ids: ["diagnosis:read-only", "diagnosis:secret-free"],
     owner: "@apex/cli",
-    entrypoint: "ApexService.diagnose",
+    entrypoint: "ApexService.validateTaskValidators",
     execution: "inline",
     boundary: "diagnosis",
   },
@@ -171,7 +171,7 @@ const ownershipGroups: readonly OwnershipGroup[] = [
   {
     ids: ["terminal:run-evidence-complete"],
     owner: "@apex/cli",
-    entrypoint: "ApexService.status",
+    entrypoint: "ApexService.ensureTerminalCompletion",
     execution: "inline",
     boundary: "terminal",
   },


### PR DESCRIPTION
## Summary
- execute inventory secret, coverage, and reconciliation validators before deployment completion
- pin operation/inventory into diagnosis and enforce read-only, current, secret-free reports
- execute terminal completeness against every active track validator
- allow only legitimate provider-owned fake omissions and account inherited gate evidence
- persist one idempotent `workflow.completed` event with full evidence accounting
- enforce runtime workflow lock on every routing and validator boundary

## Validation
- fake/native inventory mutations, diagnosis secret/evidence/future-time, terminal missing-evidence, lock-tamper, and per-track accounting regressions
- independent audit: 55 declared, 55 owned, 55 active union, no missing handlers
- full `npm run test:vnext`
- `npm run validate:vnext`
- targeted Prettier and cache-free ESLint

Tracks #573
Parent #542