### PR TITLE
feat: complete capability pack lifecycle

### DIFF
--- a/packages/capabilities/src/pack-manager.ts
+++ b/packages/capabilities/src/pack-manager.ts
@@ -8,6 +8,7 @@ const HASH = /^[0-9a-f]{64}$/;
 const EMPTY_DIGEST = createHash("sha256").update("").digest("hex");
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_OUTPUT_BYTES = 1024 * 1024;
+const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0);
 
 export type CapabilityPackRuntime = "python" | "deno" | "npm";
 export type CapabilityPackState = "installed" | "unavailable" | "blocked" | "invalid" | "not-installed";
@@ -165,16 +166,33 @@ export class CapabilityPackManager {
     }
     const staged = join(this.#localDirectory(), `rollback-${id}-${this.#idSource()}`);
     await mkdir(dirname(staged), { recursive: true });
+    let previousIsStaged = false;
+    let currentIsPrevious = false;
+    let previousIsCurrent = false;
     try {
       await rename(previous, staged);
-      if (await this.#exists(target)) await rename(target, previous);
+      previousIsStaged = true;
+      if (await this.#exists(target)) {
+        await rename(target, previous);
+        currentIsPrevious = true;
+      }
       await rename(staged, target);
+      previousIsStaged = false;
+      previousIsCurrent = true;
       const verified = await this.verify(id);
       if (verified.state !== "installed") throw new Error(verified.reason ?? "rollback verification failed");
       return { ...verified, changed: true, lock: await this.#readLock(target) };
     } catch (error) {
-      if (await this.#exists(staged)) await rename(staged, previous);
-      if (!(await this.#exists(target)) && (await this.#exists(previous))) await rename(previous, target);
+      if (previousIsCurrent) {
+        await rename(target, staged);
+        if (currentIsPrevious) await rename(previous, target);
+        await rename(staged, previous);
+      } else if (currentIsPrevious) {
+        await rename(previous, target);
+        await rename(staged, previous);
+      } else if (previousIsStaged) {
+        await rename(staged, previous);
+      }
       throw error;
     }
   }
@@ -230,6 +248,23 @@ export class CapabilityPackManager {
         changed: false,
       };
     }
+  }
+
+  async uninstall(id: string): Promise<CapabilityPackOperationResult> {
+    const definition = await this.#definition(id);
+    const target = this.#packDirectory(id);
+    const previous = `${target}.previous`;
+    const changed = (await this.#exists(target)) || (await this.#exists(previous));
+    await rm(target, { recursive: true, force: true });
+    await rm(previous, { recursive: true, force: true });
+    return {
+      id,
+      state: "not-installed",
+      ...(definition.version === undefined ? {} : { version: definition.version }),
+      requiredWorkflows: definition.requiredWorkflows ?? [],
+      action: `Run apex capability install --pack ${id}`,
+      changed,
+    };
   }
 
   async requiredForWorkflows(workflows: readonly string[]): Promise<readonly CapabilityPackStatusResult[]> {
@@ -620,7 +655,7 @@ export class CapabilityPackManager {
     const hash = createHash("sha256");
     const visit = async (directory: string): Promise<void> => {
       const entries = (await readdir(directory, { withFileTypes: true })).sort((left, right) =>
-        left.name.localeCompare(right.name),
+        compareText(left.name, right.name),
       );
       for (const entry of entries) {
         const path = join(directory, entry.name);

--- a/packages/capabilities/src/test/pack-manager.test.ts
+++ b/packages/capabilities/src/test/pack-manager.test.ts
@@ -8,6 +8,7 @@ import { CapabilityPackManager, type CapabilityPackRegistryV1 } from "../pack-ma
 import type { ProcessRequest, ProcessResult, ProcessRunnerLike } from "../process-runner.js";
 
 const roots: string[] = [];
+const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0);
 
 class FakeRunner implements ProcessRunnerLike {
   readonly requests: ProcessRequest[] = [];
@@ -49,7 +50,7 @@ async function treeDigest(rootPath: string): Promise<string> {
   const hash = createHash("sha256");
   const visit = async (directory: string): Promise<void> => {
     const entries = (await readdir(directory, { withFileTypes: true })).sort((left, right) =>
-      left.name.localeCompare(right.name),
+      compareText(left.name, right.name),
     );
     for (const entry of entries) {
       const path = join(directory, entry.name);
@@ -279,11 +280,67 @@ test("rollback restores the previously verified pack", async () => {
   await writeFile(scriptPath, "print('v2')\n");
   await writeFile(manifestPath, JSON.stringify(await registry("2.0.0")));
   assert.equal((await packs.update("governance")).installedVersion, "2.0.0");
+  const previousScript = join(workspace, ".apex", "capability-packs", "governance.previous", "discover.py");
+  await writeFile(previousScript, "print('corrupt')\n");
+  await assert.rejects(packs.rollback("governance"), /source artifact digest mismatch/);
+  assert.equal((await packs.verify("governance")).installedVersion, "2.0.0");
+  assert.equal(
+    await readFile(join(workspace, ".apex", "capability-packs", "governance", "discover.py"), "utf8"),
+    "print('v2')\n",
+  );
+  assert.equal(await readFile(previousScript, "utf8"), "print('corrupt')\n");
+  await writeFile(previousScript, "print('v1')\n");
   const rolledBack = await packs.rollback("governance");
   assert.equal(rolledBack.installedVersion, "1.0.0");
   assert.equal(
     await readFile(join(workspace, ".apex", "capability-packs", "governance", "discover.py"), "utf8"),
     "print('v1')\n",
+  );
+  const uninstalled = await packs.uninstall("governance");
+  assert.equal(uninstalled.state, "not-installed");
+  assert.equal(uninstalled.changed, true);
+  assert.equal((await packs.status("governance")).state, "not-installed");
+  await assert.rejects(lstat(join(workspace, ".apex", "capability-packs", "governance")), /ENOENT/);
+  await assert.rejects(lstat(join(workspace, ".apex", "capability-packs", "governance.previous")), /ENOENT/);
+  assert.equal((await packs.uninstall("governance")).changed, false);
+});
+
+test("uninstall preserves other packs and fails before removal when the registry is unreadable", async () => {
+  const workspace = await root();
+  const manifestRoot = join(workspace, "manifest");
+  const manifestPath = join(manifestRoot, "capability-packs.v1.json");
+  const definitions = [];
+  for (const id of ["governance", "drawio"]) {
+    const source = join(manifestRoot, id);
+    await mkdir(source, { recursive: true });
+    const script = `${id}.py`;
+    await writeFile(join(source, script), `print('${id}')\n`);
+    definitions.push({
+      id,
+      version: "1.0.0",
+      runtime: "python" as const,
+      dependencyFree: true,
+      script,
+      scriptDigest: await fileDigest(join(source, script)),
+      artifact: { type: "local-directory" as const, spec: id, digest: await treeDigest(source) },
+      executable: { command: "python", args: [script] },
+    });
+  }
+  const registry: CapabilityPackRegistryV1 = { schemaVersion: "1.0.0", packs: definitions };
+  const { manager: packs } = await manager(workspace, registry);
+  assert.equal((await packs.install("governance")).state, "installed");
+  assert.equal((await packs.install("drawio")).state, "installed");
+
+  await rm(manifestPath);
+  await assert.rejects(packs.uninstall("governance"), /ENOENT/);
+  await readFile(join(workspace, ".apex", "capability-packs", "governance", "pack.lock.json"));
+  await writeFile(manifestPath, JSON.stringify(registry));
+
+  assert.equal((await packs.uninstall("governance")).state, "not-installed");
+  assert.equal((await packs.verify("drawio")).state, "installed");
+  assert.equal(
+    await readFile(join(workspace, ".apex", "capability-packs", "drawio", "drawio.py"), "utf8"),
+    "print('drawio')\n",
   );
 });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -390,6 +390,12 @@ export async function execute(argv: string[], root = process.cwd()): Promise<unk
         required(flags, "pack"),
         typeof flags.manifest === "string" ? flags.manifest : undefined,
       );
+    case "capability uninstall":
+      confirmed(flags, "capability uninstall");
+      return service.capabilityUninstall(
+        required(flags, "pack"),
+        typeof flags.manifest === "string" ? flags.manifest : undefined,
+      );
     case "project list":
       return service.listProjects();
     case "project use":

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -353,6 +353,10 @@ export class ApexService {
     return this.capabilityPacks(manifestPath).verify(id);
   }
 
+  async capabilityUninstall(id: string, manifestPath?: string): Promise<unknown> {
+    return this.capabilityPacks(manifestPath).uninstall(id);
+  }
+
   async init(input: {
     projectId: ProjectId;
     displayName?: string;

--- a/packages/cli/src/test/adapters.test.ts
+++ b/packages/cli/src/test/adapters.test.ts
@@ -128,4 +128,5 @@ test("CLI capability commands report retained packs and require confirmation for
   assert.equal(listed.find(({ id }) => id === "azure-pricing")?.state, "not-installed");
   assert.equal(listed.find(({ id }) => id === "azure-pricing")?.reason, undefined);
   await assert.rejects(execute(["capability", "install", "--pack", "azure-pricing"], root), /requires --yes/);
+  await assert.rejects(execute(["capability", "uninstall", "--pack", "azure-pricing"], root), /requires --yes/);
 });

--- a/site/src/content/docs/vnext/cli-reference.md
+++ b/site/src/content/docs/vnext/cli-reference.md
@@ -31,6 +31,13 @@ Run `apex <command> --json` for automation. Success is written to stdout as
 | `apex update` | Optional `--customizations-source` | Three-way update managed workspace files. |
 | `apex setup` | Optional `--live` | Run readiness checks; live mode checks Azure CLI authentication. |
 | `apex doctor` | Optional `--fix --yes` | Diagnose setup and optionally repair managed files and the runtime lock. |
+| `apex capability list` | Optional `--manifest` | List capability-pack availability and installation state. |
+| `apex capability status` | `--pack`; optional `--manifest` | Show one capability pack's actionable state. |
+| `apex capability install` | `--pack --yes`; optional `--manifest --cache` | Install and verify a digest-pinned pack. |
+| `apex capability update` | `--pack --yes`; optional `--manifest --cache` | Transactionally replace a pack. |
+| `apex capability verify` | `--pack`; optional `--manifest` | Verify installed files, locks, and entrypoints. |
+| `apex capability rollback` | `--pack --yes`; optional `--manifest` | Restore the previously verified pack. |
+| `apex capability uninstall` | `--pack --yes`; optional `--manifest` | Remove current and rollback copies. |
 | `apex project list` | None | List initialized projects. |
 | `apex project use` | `--project`; optional `--run` | Select a project and run. |
 | `apex project show` | Optional `--project` | Show a project or the current project and run. |
@@ -44,7 +51,7 @@ Run `apex <command> --json` for automation. Success is written to stdout as
 | `apex task cancel` | `--task` | Cancel an issued task. |
 | `apex task stage-file` | `--task --path --file`; optional `--sha` | Stage an allowed code-generation file. |
 | `apex task generate-iac` | `--task` | Generate the selected IaC track in the bounded staging tree. |
-| `apex review resolve` | `--review --resolution` | Record a review-finding resolution. |
+| `apex review resolve` | `--file` | Record a review-finding resolution from JSON. |
 | `apex gate decide` | `--gate --decision --actor` | Approve or reject an open gate. |
 | `apex validate` | None | Validate and cache the current journal/runtime-lock result. |
 | `apex preview` | `--operation --provider`; see values below | Create a bound preview and open Gate 4. |
@@ -63,6 +70,8 @@ Run `apex <command> --json` for automation. Success is written to stdout as
 | `apex telemetry delete` | None | Delete optional telemetry. |
 | `apex cache status` | None | Count deterministic cache entries. |
 | `apex cache clear` | None | Invalidate the deterministic cache. |
+| `apex quality evaluate` | `--measurements`; optional `--scorecard` | Evaluate measurements against a scorecard. |
+| `apex quality status` | None | Read the latest quality evaluation. |
 | `apex mcp serve` | None | Serve the APEX MCP protocol over standard input/output. |
 
 The compact rows above expand to these exact accepted flags and values:
@@ -70,8 +79,13 @@ The compact rows above expand to these exact accepted flags and values:
 ```text
 init: --project; optional --name, --environment, --target, --iac, --customizations-source
 task complete: --task, --file; single output also needs --kind; optional --summary
+review resolve: --file
 preview: --operation apply|destroy --provider fake|bicep|terraform
 render: --kind status|requirements|preview|approval|inventory
+capability install/update: --pack --yes; optional --manifest, --cache
+capability status/verify: --pack; optional --manifest
+capability rollback/uninstall: --pack --yes; optional --manifest
+quality evaluate: --measurements; optional --scorecard
 writer transfer-create: --repo --branch --commit --workflow --sender --recipient --head --ttl
 evidence accept: --kind --content-type and exactly one of --file or --value; optional --required
 ```

--- a/tools/tests/vnext/pack-vnext.test.mjs
+++ b/tools/tests/vnext/pack-vnext.test.mjs
@@ -391,6 +391,29 @@ test("packs and clean-installs the vNext runtime reproducibly", { timeout: 240_0
   await readFile(join(project, ".github", "agents", "apex.agent.md"));
   await readFile(join(project, ".vscode", "mcp.json"));
   await readFile(join(project, ".apex", "runtime", "workflow.v1.json"));
+  const governancePack = "azure-governance-discovery";
+  const capability = async (args) =>
+    JSON.parse((await runInTest(apexBin, ["capability", ...args, "--json"], project)).stdout).result;
+  const absentPack = await capability(["status", "--pack", governancePack]);
+  assert.equal(absentPack.state, "not-installed");
+  const installedPack = await capability(["install", "--pack", governancePack, "--yes"]);
+  assert.equal(installedPack.state, "installed");
+  assert.equal(installedPack.changed, true);
+  assert.equal((await capability(["verify", "--pack", governancePack])).state, "installed");
+  const updatedPack = await capability(["update", "--pack", governancePack, "--yes"]);
+  assert.equal(updatedPack.state, "installed");
+  assert.equal(updatedPack.changed, true);
+  const rolledBackPack = await capability(["rollback", "--pack", governancePack, "--yes"]);
+  assert.equal(rolledBackPack.state, "installed");
+  assert.equal(rolledBackPack.changed, true);
+  const removedPack = await capability(["uninstall", "--pack", governancePack, "--yes"]);
+  assert.equal(removedPack.state, "not-installed");
+  assert.equal(removedPack.changed, true);
+  assert.equal((await capability(["status", "--pack", governancePack])).state, "not-installed");
+  await assert.rejects(readFile(join(project, ".apex", "capability-packs", governancePack, "pack.lock.json")), {
+    code: "ENOENT",
+  });
+  await readFile(join(project, ".apex", "runtime", "capability-packs.registry.json"));
   await writeFile(join(project, "keep.txt"), "preserve me\n", "utf8");
   const lock = JSON.parse(await readFile(join(project, ".apex", "customizations.lock.json"), "utf8"));
   for (const file of [...lock.files, ...lock.runtime]) {


### PR DESCRIPTION
## Description

Adds safe, idempotent capability-pack uninstall through the manager, service, and CLI. Hardens rollback recovery and locale-independent pack hashing, proves pack isolation, and exercises the full lifecycle from a packed offline clean consumer.

## Related Issue

Refs #577
Parent #542

## Type of Change

- [ ] New prompt guide section
- [ ] New infrastructure module (Bicep/Terraform)
- [ ] Agent definition update (.github/agents/)
- [x] Documentation update
- [x] Bug fix
- [ ] Refactoring (no functional changes)
- [x] Configuration/workflow change
- [ ] MCP server enhancement (azure-pricing-mcp)

## Token / latency impact (Plan 01 Phase 5)

This change affects input-token budget / per-call latency:

- [ ] YES
- [x] NO

## Workflow Used

- [ ] Multi-step workflow
- [x] Direct implementation (simple change)
- [ ] Copilot Coding Agent (autonomous)
- [ ] Manual implementation

## Changes Made

- Added confirmed `capability uninstall` routing and service support.
- Made uninstall idempotent and definition-validated before deletion.
- Restored all rollback directories transactionally after verification failure.
- Switched capability tree hashing to ordinal ordering.
- Added manager, CLI, multi-pack isolation, and packed clean-consumer lifecycle coverage.
- Corrected capability, review, and quality rows in the CLI reference.

## Testing Performed

- [x] `npm run test:vnext`
- [x] `npm run test:vnext-pack`
- [x] `npm run validate:vnext`
- [x] `npm test --workspace @apex/capabilities`
- [x] `npm test --workspace @apex/cli`
- [x] `npm run format:check`
- [x] Targeted ESLint
- [x] `npm run lint:md`
- [x] `npm run lint:links:docs`
- [x] `npm run lint:docs-freshness`
- [x] Pre-commit and pre-push hooks

## Pre-Submission Checklist

- [x] PR touches fewer than 50 files
- [x] Commit messages follow conventional commits format
- [x] No hardcoded secrets, subscription IDs, or sensitive data
- [x] Markdown linting passes
- [x] Internal documentation links verified
- [ ] CI workflow passes

## Additional Notes

Targets `feat/apex-vnext-rewrite`; this PR does not target or merge to `main`. The unrelated untracked `uv.lock` was intentionally excluded.