### PR TITLE
fix: Make packed install cache explicit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -960,9 +960,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.52",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
-      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
@@ -6699,7 +6699,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "0.34.52"
+        "@sinclair/typebox": "0.34.49"
       },
       "engines": {
         "node": ">=24"
@@ -6711,7 +6711,7 @@
       "license": "MIT",
       "dependencies": {
         "@apex/contracts": "0.1.0",
-        "@sinclair/typebox": "0.34.52"
+        "@sinclair/typebox": "0.34.49"
       },
       "engines": {
         "node": ">=24"
@@ -6738,7 +6738,7 @@
         "@apex/contracts": "0.1.0",
         "@apex/kernel": "0.1.0",
         "@apex/renderers": "0.1.0",
-        "@sinclair/typebox": "0.34.52"
+        "@sinclair/typebox": "0.34.49"
       },
       "engines": {
         "node": ">=24"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -30,7 +30,7 @@
     "schemas"
   ],
   "dependencies": {
-    "@sinclair/typebox": "0.34.52"
+    "@sinclair/typebox": "0.34.49"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@apex/contracts": "0.1.0",
-    "@sinclair/typebox": "0.34.52"
+    "@sinclair/typebox": "0.34.49"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -30,7 +30,7 @@
     "@apex/contracts": "0.1.0",
     "@apex/kernel": "0.1.0",
     "@apex/renderers": "0.1.0",
-    "@sinclair/typebox": "0.34.52"
+    "@sinclair/typebox": "0.34.49"
   },
   "scripts": {
     "build": "tsc -b",

--- a/tools/tests/vnext/pack-vnext.test.mjs
+++ b/tools/tests/vnext/pack-vnext.test.mjs
@@ -362,27 +362,37 @@ test("packs and clean-installs the vNext runtime reproducibly", { timeout: 240_0
     listing.every((path) => !path.includes("/dist/test/") && !path.endsWith(".map") && !path.endsWith(".tsbuildinfo")),
   );
 
-  const project = join(temporaryRoot, "consumer");
-  await mkdir(project, { recursive: true });
-  await runInTest("npm", ["init", "--yes"], project);
   const runtimeTarballs = release.packages.map((entry) => join(outputDirectory, entry.file));
-  const approvedCache = (await runInTest("npm", ["config", "get", "cache"])).stdout.trim();
-  assert.ok(approvedCache.length > 0);
+  const approvedCache = join(temporaryRoot, "approved-npm-cache");
+  const createConsumer = async (name) => {
+    const directory = join(temporaryRoot, name);
+    await mkdir(directory, { recursive: true });
+    await runInTest("npm", ["init", "--yes"], directory);
+    return directory;
+  };
+  const installCandidate = async (directory, offline = false) =>
+    await runInTest(
+      "npm",
+      [
+        "install",
+        ...(offline ? ["--offline"] : []),
+        "--cache",
+        approvedCache,
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        ...runtimeTarballs,
+      ],
+      directory,
+    );
+
+  const unpreparedConsumer = await createConsumer("consumer-unprepared");
+  await assert.rejects(installCandidate(unpreparedConsumer, true), /ENOTCACHED/);
+  const cacheSeed = await createConsumer("cache-seed");
+  await installCandidate(cacheSeed);
   await runInTest("npm", ["cache", "verify", "--cache", approvedCache]);
-  await runInTest(
-    "npm",
-    [
-      "install",
-      "--offline",
-      "--cache",
-      approvedCache,
-      "--ignore-scripts",
-      "--no-audit",
-      "--no-fund",
-      ...runtimeTarballs,
-    ],
-    project,
-  );
+  const project = await createConsumer("consumer");
+  await installCandidate(project, true);
 
   const apexBin = join(project, "node_modules", ".bin", process.platform === "win32" ? "apex.cmd" : "apex");
   const version = JSON.parse((await runInTest(apexBin, ["version", "--json"], project)).stdout);


### PR DESCRIPTION
## Description

Makes the packed clean-consumer test independent of the runner ambient npm cache. The test now proves an empty dedicated cache fails closed, seeds that cache through the configured registry, and installs the candidate offline into a separate clean consumer.

Local validation used a process-scoped `npm_config_registry=https://packagefeedproxy.microsoft.io/npm/`; no registry override is committed. CI continues to use `registry.npmjs.org` from the normalized lockfile. TypeBox is pinned to stable `0.34.49`, the latest exact release available through both lanes.

## Related Issue

Refs #582
Parent #542

## Changes

- Replace ambient npm cache reuse with an isolated, explicitly prepared cache.
- Prove an unprepared offline install returns `ENOTCACHED`.
- Install the candidate offline into a distinct clean consumer.
- Pin TypeBox `0.34.49` across contracts, kernel, and testkit.
- Keep all lockfile URLs normalized to public npm with SHA-512 integrity.

## Validation

- [x] Proxy-backed `npm ci` from the normalized public lockfile
- [x] Proxy-backed `npm run test:vnext-pack`
- [x] `npm run test:vnext`
- [x] `npm run validate:vnext`
- [x] `npm run format:check`
- [x] `npm run lint:json`
- [x] Targeted ESLint
- [x] Pre-commit and pre-push hooks
- [ ] GitHub CI using public npm

## Notes

Targets `feat/apex-vnext-rewrite`; this PR does not target `main`. The unrelated untracked `uv.lock` was excluded.