### PR TITLE
fix: Launch MCP from workspace CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ for full details on this and all prior releases.
 - fix(vnext): replaced polynomial storage-security regular expressions over generated Bicep and Terraform source with
   a bounded line-oriented assignment scan. Adversarial dual-track coverage protects the fix in
   [#537](https://github.com/jonathan-vella/apex/issues/537).
+- fix(vnext): launch the managed MCP server through the installed workspace-local CLI instead of assuming the VS Code
+  extension host exposes a bare `apex` command on `PATH`; packed clean-consumer tests now connect over stdio and call
+  kernel status through the generated configuration.
 
 ### Changed (Model migration — Claude Sonnet 4.6 → Claude Sonnet 5)
 

--- a/customizations/.vscode/mcp.json
+++ b/customizations/.vscode/mcp.json
@@ -2,8 +2,9 @@
   "servers": {
     "apex": {
       "type": "stdio",
-      "command": "apex",
+      "command": "node",
       "args": [
+        "${workspaceFolder}/node_modules/@apex/cli/dist/cli.js",
         "mcp",
         "serve"
       ],

--- a/packages/cli/src/test/customizations.test.ts
+++ b/packages/cli/src/test/customizations.test.ts
@@ -44,7 +44,16 @@ test("init installs bundled customizations and runtime config by default", async
   const service = new ApexService(root);
   await service.init({ projectId: "demo" });
   assert.match(await readFile(join(root, ".github", "agents", "apex.agent.md"), "utf8"), /name: APEX/);
-  assert.match(await readFile(join(root, ".vscode", "mcp.json"), "utf8"), /apex/);
+  assert.deepEqual(JSON.parse(await readFile(join(root, ".vscode", "mcp.json"), "utf8")), {
+    servers: {
+      apex: {
+        type: "stdio",
+        command: "node",
+        args: ["${workspaceFolder}/node_modules/@apex/cli/dist/cli.js", "mcp", "serve"],
+        cwd: "${workspaceFolder}",
+      },
+    },
+  });
   assert.match(await readFile(join(root, ".apex", "runtime", "workflow.v1.json"), "utf8"), /apex-workflow-v1/);
   const registry = JSON.parse(
     await readFile(join(root, ".apex", "runtime", "capability-packs.registry.json"), "utf8"),

--- a/tools/scripts/validate-vnext.mjs
+++ b/tools/scripts/validate-vnext.mjs
@@ -659,14 +659,16 @@ function validateMcp(model, findings) {
   if (
     !apex ||
     apex.type !== "stdio" ||
-    apex.command !== "apex" ||
-    JSON.stringify(apex.args) !== JSON.stringify(["mcp", "serve"]) ||
+    apex.command !== "node" ||
+    JSON.stringify(apex.args) !==
+      JSON.stringify(["${workspaceFolder}/node_modules/@apex/cli/dist/cli.js", "mcp", "serve"]) ||
+    apex.cwd !== "${workspaceFolder}" ||
     (apex.env && Object.keys(apex.env).length > 0)
   )
     finding(
       findings,
       "mcp.launch",
-      "Managed MCP config must only launch `apex mcp serve` without environment secrets",
+      "Managed MCP config must launch the workspace-local APEX CLI through Node without environment secrets",
       "customizations/.vscode/mcp.json",
     );
 }

--- a/tools/tests/vnext/pack-vnext.test.mjs
+++ b/tools/tests/vnext/pack-vnext.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 
 const root = resolve(import.meta.dirname, "../../..");
 const resistantProcessTree = join(import.meta.dirname, "fixtures", "resistant-process-tree.mjs");
@@ -399,7 +400,30 @@ test("packs and clean-installs the vNext runtime reproducibly", { timeout: 240_0
   assert.deepEqual(version, { ok: true, result: { version: "0.1.0", bundleVersion: "0.1.0", configVersion: "1.0.0" } });
   await runInTest(apexBin, ["init", "--project", "demo", "--json"], project);
   await readFile(join(project, ".github", "agents", "apex.agent.md"));
-  await readFile(join(project, ".vscode", "mcp.json"));
+  const mcpConfig = JSON.parse(await readFile(join(project, ".vscode", "mcp.json"), "utf8")).servers.apex;
+  const workspaceValue = (value) => value.replaceAll("${workspaceFolder}", project);
+  const sdkRoot = join(project, "node_modules", "@modelcontextprotocol", "sdk", "dist", "esm", "client");
+  const [{ Client }, { StdioClientTransport }] = await Promise.all([
+    import(pathToFileURL(join(sdkRoot, "index.js")).href),
+    import(pathToFileURL(join(sdkRoot, "stdio.js")).href),
+  ]);
+  const mcpClient = new Client({ name: "packed-consumer-test", version: "1.0.0" });
+  const mcpTransport = new StdioClientTransport({
+    command: workspaceValue(mcpConfig.command),
+    args: mcpConfig.args.map(workspaceValue),
+    cwd: workspaceValue(mcpConfig.cwd),
+    stderr: "pipe",
+  });
+  try {
+    await mcpClient.connect(mcpTransport);
+    const tools = await mcpClient.listTools();
+    assert.ok(tools.tools.some(({ name }) => name === "status"));
+    const status = await mcpClient.callTool({ name: "status", arguments: {} });
+    assert.equal(status.isError, undefined);
+    assert.equal(status.structuredContent.run.projectId, "demo");
+  } finally {
+    await mcpClient.close();
+  }
   await readFile(join(project, ".apex", "runtime", "workflow.v1.json"));
   const governancePack = "azure-governance-discovery";
   const capability = async (args) =>

--- a/tools/tests/vnext/validate-vnext.test.mjs
+++ b/tools/tests/vnext/validate-vnext.test.mjs
@@ -71,6 +71,14 @@ test("rejects a missing MCP tool", () => {
   assert.ok(hasRule(result, "customization.mcp-tool"));
 });
 
+test("rejects a PATH-dependent MCP launch", () => {
+  const result = mutate((model) => {
+    model.customization.mcp.servers.apex.command = "apex";
+    model.customization.mcp.servers.apex.args = ["mcp", "serve"];
+  });
+  assert.ok(hasRule(result, "mcp.launch"));
+});
+
 test("rejects an unsafe managed path", () => {
   const result = mutate((model) => {
     model.customization.manifest.managedFiles.push("../package.json");


### PR DESCRIPTION
## Description

Fixes the exact clean-consumer VS Code failure `spawn apex ENOENT`. The managed MCP configuration now launches Node with the installed workspace-local CLI entrypoint instead of assuming the remote extension host adds `node_modules/.bin` to PATH.

## Related Issue

Refs #587
Parent #586

## Evidence

- Before: VS Code 1.129.0 remote extension host reported `spawn apex ENOENT`.
- After managed update and a fresh window: MCP connected and APEX returned kernel-backed live-demo status/next action.
- Packed clean-consumer test now loads its own MCP SDK, connects through generated config, lists tools, and calls status.
- Validator mutation rejects the old PATH-dependent shape.

## Validation

- [x] `npm run test:vnext`
- [x] `npm run validate:vnext`
- [x] `npm run test:vnext-validator`
- [x] Proxy-backed `npm run test:vnext-pack`
- [x] Targeted ESLint, formatting, JSON, Markdown
- [x] Real VS Code 1.129.0 clean-consumer MCP status call
- [x] Pre-commit and pre-push hooks

## Safety

No registry override, credential, Azure action, OIDC request, publication, or merge to main.