### PR TITLE
fix: Allow post-template live evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ for full details on this and all prior releases.
 - fix(vnext): launch the managed MCP server through the installed workspace-local CLI instead of assuming the VS Code
   extension host exposes a bare `apex` command on `PATH`; packed clean-consumer tests now connect over stdio and call
   kernel status through the generated configuration.
+- fix(vnext): allow live qualification scenarios to start and complete after their unavailable-by-default evidence
+  template is created, while rejecting pre-template and inverted timestamps.
 
 ### Changed (Model migration — Claude Sonnet 4.6 → Claude Sonnet 5)
 

--- a/packages/contracts/src/evidence.ts
+++ b/packages/contracts/src/evidence.ts
@@ -200,7 +200,7 @@ export function hasValidLiveQualification(qualification: LiveQualificationV1): b
     qualification.scenarios.every(({ startedAt, completedAt }) => {
       const started = Date.parse(startedAt);
       const completed = Date.parse(completedAt);
-      return Number.isFinite(started) && Number.isFinite(completed) && started <= completed && completed <= createdAt;
+      return Number.isFinite(started) && Number.isFinite(completed) && createdAt <= started && started <= completed;
     })
   );
 }

--- a/packages/contracts/src/test/contracts.test.ts
+++ b/packages/contracts/src/test/contracts.test.ts
@@ -60,6 +60,7 @@ const hash = "a".repeat(64);
 const otherHash = "b".repeat(64);
 const timestamp = "2026-07-13T12:00:00.000Z";
 const expiry = "2026-07-13T13:00:00.000Z";
+const completion = "2026-07-13T14:00:00.000Z";
 
 FormatRegistry.Set("date-time", (value) => Number.isFinite(Date.parse(value)));
 FormatRegistry.Set(
@@ -112,8 +113,8 @@ describe("Wave 1 contracts", () => {
       environment: "sandbox",
       targetScope: "subscription/example",
       actor: "maintainer",
-      startedAt: timestamp,
-      completedAt: expiry,
+      startedAt: expiry,
+      completedAt: completion,
       toolVersions: { apex: "0.1.0" },
       outcome: "pass",
       evidenceRefs: [hash],
@@ -130,7 +131,7 @@ describe("Wave 1 contracts", () => {
         releaseManifestHash: otherHash,
         runtimeBundleHash: "c".repeat(64),
       },
-      createdAt: expiry,
+      createdAt: timestamp,
       evidenceManifestHash: "d".repeat(64),
       scenarios,
     };
@@ -149,7 +150,16 @@ describe("Wave 1 contracts", () => {
     assert.equal(
       hasValidLiveQualification({
         ...qualification,
-        createdAt: timestamp,
+        createdAt: completion,
+      }),
+      false,
+    );
+    assert.equal(
+      hasValidLiveQualification({
+        ...qualification,
+        scenarios: qualification.scenarios.map((scenario, index) =>
+          index === 0 ? { ...scenario, startedAt: completion, completedAt: expiry } : scenario,
+        ),
       }),
       false,
     );

--- a/site/src/content/docs/vnext/live-qualification.md
+++ b/site/src/content/docs/vnext/live-qualification.md
@@ -50,7 +50,8 @@ npm run live:vnext -- template \
 ```
 
 The command refuses to overwrite either output. Every scenario starts as `unavailable` with an explicit owner and next
-action. This prevents an unexecuted scenario from appearing successful.
+action. This prevents an unexecuted scenario from appearing successful. Top-level `createdAt` records template creation;
+each scenario records an actual `startedAt` and `completedAt` at or after that instant.
 
 ## Execute Human-Owned Scenarios
 


### PR DESCRIPTION
## Description

Corrects the live evidence timestamp invariant so unavailable-by-default templates can be created before honest manual execution. Scenarios now require `createdAt <= startedAt <= completedAt`.

## Related Issue

Refs #589
Parent #586

## Validation

- [x] Full contracts suite and deterministic schema check
- [x] `npm run test:vnext-validator`
- [x] `npm run validate:vnext`
- [x] Markdown, links, ESLint, formatting
- [x] Adversarial pre-template and inverted timestamp tests

## Safety

No runtime mutation, cloud action, registry change, publication, or merge to main.