### PR TITLE
fix: Protect local APEX state from Git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ for full details on this and all prior releases.
   kernel status through the generated configuration.
 - fix(vnext): allow live qualification scenarios to start and complete after their unavailable-by-default evidence
   template is created, while rejecting pre-template and inverted timestamps.
+- fix(vnext): install a nested `.apex/.gitignore` that excludes local leases, work staging, saved plans, and
+  recomputable caches while preserving repository-backed project journals and evidence for cross-device resume.
 
 ### Changed (Model migration — Claude Sonnet 4.6 → Claude Sonnet 5)
 

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -107,6 +107,7 @@ import {
 const ZERO_HASH = "0".repeat(64);
 const TASK_TTL_MS = 24 * 60 * 60 * 1000;
 const PREVIEW_TTL_MS = 24 * 60 * 60 * 1000;
+const APEX_GITIGNORE = "/cache/\n/local/\n/work/\n";
 
 interface Selection {
   projectId: ProjectId;
@@ -368,6 +369,7 @@ export class ApexService {
     await this.assertCleanInitialization();
     await mkdir(join(this.root, ".apex"), { recursive: true });
     try {
+      await this.ensureLocalGitBoundary();
       const assets = await resolveBundledAssets();
       await this.installCustomizations(input.customizationsSource ?? assets.customizations, false, assets.config);
       await this.installCapabilityAssets(assets);
@@ -398,6 +400,7 @@ export class ApexService {
 
   async update(customizationsSource?: string): Promise<{ updated: string[] }> {
     const selection = await this.selection();
+    await this.ensureLocalGitBoundary();
     const assets = await resolveBundledAssets();
     const source = customizationsSource ?? assets.customizations;
     const updated = await this.installCustomizations(source, true, assets.config);
@@ -1547,6 +1550,7 @@ export class ApexService {
   ): Promise<{ healthy: boolean; checks: DoctorCheck[]; remedies: string[]; nextAction: string }> {
     const apexExists = await this.exists(join(this.root, ".apex"));
     if (fix && yes && apexExists) {
+      await this.ensureLocalGitBoundary(true);
       const assets = await resolveBundledAssets();
       await this.installCustomizations(assets.customizations, true, assets.config, true);
       await this.installCapabilityAssets(assets);
@@ -1579,6 +1583,7 @@ export class ApexService {
         value: auth.detail,
         remedy: "Authenticate with Azure outside doctor, then run setup --live",
       });
+      checks.push(await this.localGitBoundaryCheck());
       checks.push(...(await this.managedFileChecks()));
       checks.push(...(await this.runtimeLockChecks(run)));
       const route = await this.route(run, await this.journal(run).replay());
@@ -3095,6 +3100,47 @@ export class ApexService {
           remedy: "Run doctor --fix --yes to reinstall the runtime lock",
         },
       ];
+    }
+  }
+
+  private async ensureLocalGitBoundary(repair = false): Promise<void> {
+    const apexRoot = join(this.root, ".apex");
+    const path = join(apexRoot, ".gitignore");
+    await this.assertSafeDestination(apexRoot, path);
+    const current = await this.readOptional(path);
+    if (current?.toString("utf8") === APEX_GITIGNORE) return;
+    if (current !== undefined && !repair)
+      throw new ApexError("APEX_CONFLICT", "APEX local Git boundary was modified", EXIT_CODES.conflict);
+    await atomicWriteBytes(path, Buffer.from(APEX_GITIGNORE));
+  }
+
+  private async localGitBoundaryCheck(): Promise<DoctorCheck> {
+    const path = join(this.root, ".apex", ".gitignore");
+    try {
+      if (!(await this.pathExistsLstat(path))) {
+        return {
+          id: "local-git-boundary",
+          ok: false,
+          value: "missing",
+          remedy: "Run doctor --fix --yes to restore the APEX local Git boundary",
+        };
+      }
+      await this.assertSafeExistingPath(join(this.root, ".apex"), path);
+      const actual = await readFile(path);
+      const actualHash = sha256Bytes(actual);
+      return {
+        id: "local-git-boundary",
+        ok: actual.toString("utf8") === APEX_GITIGNORE,
+        value: actualHash,
+        remedy: "Run doctor --fix --yes to restore the APEX local Git boundary",
+      };
+    } catch (error) {
+      return {
+        id: "local-git-boundary",
+        ok: false,
+        value: error instanceof Error ? error.message : "invalid",
+        remedy: "Run doctor --fix --yes to restore the APEX local Git boundary",
+      };
     }
   }
 

--- a/packages/cli/src/test/customizations.test.ts
+++ b/packages/cli/src/test/customizations.test.ts
@@ -54,6 +54,7 @@ test("init installs bundled customizations and runtime config by default", async
       },
     },
   });
+  assert.equal(await readFile(join(root, ".apex", ".gitignore"), "utf8"), "/cache/\n/local/\n/work/\n");
   assert.match(await readFile(join(root, ".apex", "runtime", "workflow.v1.json"), "utf8"), /apex-workflow-v1/);
   const registry = JSON.parse(
     await readFile(join(root, ".apex", "runtime", "capability-packs.registry.json"), "utf8"),
@@ -213,6 +214,22 @@ test("doctor previews remedies without applying fixes", async () => {
   const result = await new ApexService(await tempRoot()).doctor(true, false);
   assert.equal(result.healthy, false);
   assert.match(result.remedies.join(" "), /Preview: Run apex init/);
+});
+
+test("update rejects and doctor repairs a modified local Git boundary", async () => {
+  const root = await tempRoot();
+  const service = new ApexService(root);
+  await service.init({ projectId: "demo" });
+  const boundary = join(root, ".apex", ".gitignore");
+  await writeFile(boundary, "/local/\n");
+  await assert.rejects(service.update(), /local Git boundary was modified/);
+  const doctor = await service.doctor();
+  const boundaryCheck = doctor.checks.find(({ id }) => id === "local-git-boundary");
+  assert.equal(boundaryCheck?.ok, false);
+  assert.match(boundaryCheck?.value ?? "", /^[0-9a-f]{64}$/);
+  assert.notEqual(boundaryCheck?.value, "/local/\n");
+  await service.doctor(true, true);
+  assert.equal(await readFile(boundary, "utf8"), "/cache/\n/local/\n/work/\n");
 });
 
 test("init writes a real runtime lock and doctor detects managed tampering", async () => {

--- a/site/src/content/docs/vnext/security.md
+++ b/site/src/content/docs/vnext/security.md
@@ -50,8 +50,9 @@ content-addressed storage. Required approval and deployment attestations are par
 telemetry is disabled by default and can be consented to, exported, or deleted independently.
 
 Never commit credentials, secret values, Terraform state, saved Terraform plan files, secret-bearing transient output,
-or `.apex/local/`. Provider configuration must contain nonsecret settings only; the CLI rejects secret-like keys.
-Resolve credentials only at operation time through Azure CLI, OIDC, Managed Identity, or another approved external
-credential source.
+or `.apex/local/`. APEX installs `.apex/.gitignore` to exclude `local/`, `work/`, and `cache/` while preserving
+repository-backed locks, objects, projects, journals, refs, and views. Provider configuration must contain nonsecret
+settings only; the CLI rejects secret-like keys. Resolve credentials only at operation time through Azure CLI, OIDC,
+Managed Identity, or another approved external credential source.
 
 Use the [operations guide](../operations/) to configure providers without secrets.

--- a/tools/tests/vnext/pack-vnext.test.mjs
+++ b/tools/tests/vnext/pack-vnext.test.mjs
@@ -398,6 +398,7 @@ test("packs and clean-installs the vNext runtime reproducibly", { timeout: 240_0
   const apexBin = join(project, "node_modules", ".bin", process.platform === "win32" ? "apex.cmd" : "apex");
   const version = JSON.parse((await runInTest(apexBin, ["version", "--json"], project)).stdout);
   assert.deepEqual(version, { ok: true, result: { version: "0.1.0", bundleVersion: "0.1.0", configVersion: "1.0.0" } });
+  await runInTest("git", ["init", "--initial-branch", "qualification"], project);
   await runInTest(apexBin, ["init", "--project", "demo", "--json"], project);
   await readFile(join(project, ".github", "agents", "apex.agent.md"));
   const mcpConfig = JSON.parse(await readFile(join(project, ".vscode", "mcp.json"), "utf8")).servers.apex;
@@ -424,6 +425,15 @@ test("packs and clean-installs the vNext runtime reproducibly", { timeout: 240_0
   } finally {
     await mcpClient.close();
   }
+  for (const path of [".apex/local/run/saved.tfplan", ".apex/work/run/task/output.json", ".apex/cache/content/item"]) {
+    await mkdir(join(project, path, ".."), { recursive: true });
+    await writeFile(join(project, path), "derived\n");
+    await runInTest("git", ["check-ignore", "--quiet", path], project);
+  }
+  await assert.rejects(
+    runInTest("git", ["check-ignore", "--quiet", ".apex/projects/demo/project.json"], project),
+    /failed \(1\)/,
+  );
   await readFile(join(project, ".apex", "runtime", "workflow.v1.json"));
   const governancePack = "azure-governance-discovery";
   const capability = async (args) =>
@@ -462,6 +472,7 @@ test("packs and clean-installs the vNext runtime reproducibly", { timeout: 240_0
   assert.equal(uninstall.ok, true);
   assert.deepEqual(uninstall.result.conflicts, []);
   await assert.rejects(readFile(join(project, ".github", "agents", "apex.agent.md")), { code: "ENOENT" });
+  assert.equal(await readFile(join(project, ".apex", ".gitignore"), "utf8"), "/cache/\n/local/\n/work/\n");
   await assert.rejects(readFile(join(project, ".apex", "customizations.lock.json")), { code: "ENOENT" });
   assert.equal(await readFile(join(project, "keep.txt"), "utf8"), "preserve me\n");
   await readFile(join(project, ".apex", "runtime", "workflow.v1.json"));


### PR DESCRIPTION
## Description

Installs a core-owned nested `.apex/.gitignore` that excludes only local/, work/, and cache/. Repository-backed locks, objects, projects, journals, refs, and views remain visible for cross-device resume.

## Related Issue

Refs #591
Parent #586

## Behavior

- Init creates the exact boundary.
- Update refuses a modified boundary.
- Doctor reports only a digest and repairs with explicit `--fix --yes`.
- Customization uninstall preserves the boundary.
- No user root `.gitignore` is changed.

## Validation

- [x] Full `test:vnext` and `validate:vnext`
- [x] Full CLI customization lifecycle suite
- [x] Packed clean consumer: `git check-ignore` for local/work/cache
- [x] Packed clean consumer: project journal remains Git-visible
- [x] Packed MCP and capability lifecycle
- [x] Lint, formatting, JSON, Markdown, links, hooks, secrets scan

## Safety

No local state was pushed, no credential was read, and no Azure/OIDC/publication/main merge occurred.