### PR TITLE
fix(mcp): Return valid requirements input result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ for full details on this and all prior releases.
   template is created, while rejecting pre-template and inverted timestamps.
 - fix(vnext): install a nested `.apex/.gitignore` that excludes local leases, work staging, saved plans, and
   recomputable caches while preserving repository-backed project journals and evidence for cross-device resume.
+- fix(vnext): return a valid structured MCP acknowledgement after recording requirements input instead of emitting
+  an invalid tool result after the journal mutation succeeds.
 
 ### Changed (Model migration — Claude Sonnet 4.6 → Claude Sonnet 5)
 

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -40,9 +40,10 @@ export function createMcpServer(service: ApexService): McpServer {
   server.registerTool("taskContext", { inputSchema: { taskId: z.string() } }, async ({ taskId }) =>
     result(await service.taskContext(taskId)),
   );
-  server.registerTool("recordRequirementsInput", { inputSchema: { value: z.unknown() } }, async ({ value }) =>
-    result(await service.recordRequirementsInput(value)),
-  );
+  server.registerTool("recordRequirementsInput", { inputSchema: { value: z.unknown() } }, async ({ value }) => {
+    await service.recordRequirementsInput(value);
+    return result({ recorded: true });
+  });
   server.registerTool(
     "stageArtifact",
     {

--- a/packages/cli/src/test/adapters.test.ts
+++ b/packages/cli/src/test/adapters.test.ts
@@ -60,6 +60,13 @@ test("MCP registers only narrow tools and calls the service", async () => {
   const response = await client.callTool({ name: "status", arguments: {} });
   assert.equal(response.isError, undefined);
   assert.equal((response.structuredContent as { run: { projectId: string } }).run.projectId, "demo");
+  const recorded = await client.callTool({
+    name: "recordRequirementsInput",
+    arguments: { value: { workload: "test" } },
+  });
+  assert.equal(recorded.isError, undefined);
+  assert.deepEqual(recorded.structuredContent, { recorded: true });
+  assert.equal((await service.nextTask()).status, "task");
   await client.close();
   await server.close();
 });


### PR DESCRIPTION
## Description

Returns an explicit `{ recorded: true }` MCP result after `recordRequirementsInput` commits its journal event. This prevents the SDK from rejecting a successful mutation because `content[0].text` was undefined.

## Related Issue

Closes #593
Parent #586

## Validation

- [x] Live packed-client reproduction confirmed the journal mutation followed by MCP `-32602`
- [x] In-memory SDK regression validates the response and recorded workflow effect
- [x] Full `qualify:vnext` suite
- [x] Changed-file ESLint, Markdown lint, Prettier, TypeScript diagnostics
- [x] Commit hooks and redacted secrets scan

## Safety

No Azure operation, package publication, synthetic-state push, or merge to `main` occurred.