### PR TITLE
fix(ci): Guard dev container config restore

### DIFF
--- a/.github/workflows/validate-devcontainer-base.yml
+++ b/.github/workflows/validate-devcontainer-base.yml
@@ -210,9 +210,12 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-      - name: Remove generated validation config
+      - name: Restore original dev container config
         if: always()
-        run: cp "${RUNNER_TEMP}/devcontainer.original.json" .devcontainer/devcontainer.json
+        run: |
+          if [[ -f "${RUNNER_TEMP}/devcontainer.original.json" ]]; then
+            cp "${RUNNER_TEMP}/devcontainer.original.json" .devcontainer/devcontainer.json
+          fi
 
   compare:
     name: Compare base-image verdicts


### PR DESCRIPTION
## Summary

- rename the cleanup step to describe restoration accurately
- restore `devcontainer.json` only when its backup exists
- prevent `always()` cleanup from masking the original matrix failure

## Validation

- missing-backup and present-backup behavior checks
- `npm run lint:safe-shell`
- `npx --no-install prettier --check .github/workflows/validate-devcontainer-base.yml`
- YAML parse with `js-yaml`
- `git diff --check`

Addresses the Copilot review comment on #633.