### PR TITLE
fix(mcp): constrain compatible SDK range

### DIFF
--- a/tools/mcp-servers/azure-pricing/pyproject.toml
+++ b/tools/mcp-servers/azure-pricing/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
 dependencies = [
-    "mcp>=1.27.0",
+    "mcp>=1.27.0,<1.29.0",
     "aiohttp>=3.14.1",
     "pydantic>=2.13.4",
     "cachetools>=7.1.4",


### PR DESCRIPTION
## Summary
- constrain the MCP SDK to the validated 1.27–1.28 API range
- prevent newer SDK API changes from breaking Azure Pricing MCP tests

## Validation
- parsed the updated pyproject manifest with Python tomllib
- instantiated the server with the local mcp 1.28.1 environment
- full pytest execution is deferred to CI because the local environment blocks package installation