### PR TITLE
chore(pricing-mcp): update aiohttp requirement

### DIFF
--- a/tools/mcp-servers/azure-pricing/pyproject.toml
+++ b/tools/mcp-servers/azure-pricing/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.27.0,<1.29.0",
-    "aiohttp>=3.14.1",
+    "aiohttp>=3.14.3",
     "pydantic>=2.13.4",
     "cachetools>=7.1.4",
 ]


### PR DESCRIPTION
Supersedes #636, whose Dependabot branch conflicts with the merged MCP compatibility constraint. Preserves the same update: aiohttp >=3.14.1 to >=3.14.3.\n\nValidation: parsed the updated pyproject manifest with Python tomllib.