### PR TITLE
chore(agents): upgrade MAI Code Flash model

### DIFF
--- a/.github/agents/01-orchestrator.agent.md
+++ b/.github/agents/01-orchestrator.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 01-Orchestrator
 description: Master orchestrator for the multi-step Azure platform engineering workflow. Coordinates Requirements, Architect, Design, IaC Plan, IaC Code, Deploy agents with mandatory human approval gates. Routes Bicep or Terraform tracks via decisions.iac_tool.
-model: ["MAI-Code-1-Flash"]
+model: ["MAI-Code-1.1-Flash"]
 argument-hint: Describe the Azure platform engineering project you want to build end-to-end
 user-invocable: true
 agents:
@@ -198,7 +198,7 @@ subagent cannot exceed the cost tier of the parent. If the parent requests a
 higher-tier model, the subagent silently falls back to the parent's tier.
 [Reference](https://code.visualstudio.com/docs/copilot/agents/subagents).
 
-This orchestrator runs at **standard** tier (MAI-Code-1-Flash). The step agents and
+This orchestrator runs at **standard** tier (MAI-Code-1.1-Flash). The step agents and
 the challenger run at **medium** (GPT-5.6-Luna / GPT-5.6-Terra / Sonnet 5) or
 **high** (Claude Opus 5)
 tiers. Calling them via `#runSubagent` would silently downgrade them to
@@ -544,7 +544,7 @@ Orchestrator with the project name — no special resume prompt needed.
 | `high`     | Claude Opus 5     | Architecture, Planning                                                                           |
 | `medium`   | Claude Sonnet 5   | **Requirements**, Design, CodeGen, As-Built, Context Optimizer, validation + preview subagents    |
 | `medium`   | GPT-5.6-Terra     | Diagnose, E2E orchestrator, challenger review subagent                                            |
-| `standard` | MAI-Code-1-Flash  | **Orchestrator** (handoff-only routing)                                                           |
+| `standard` | MAI-Code-1.1-Flash  | **Orchestrator** (handoff-only routing)                                                           |
 | `codex`    | GPT-5.6-Luna      | Governance, Deploy, Challenger, cost estimate subagent                                            |
 
 > The canonical assignments live in

--- a/.github/instructions/agent-authoring.instructions.md
+++ b/.github/instructions/agent-authoring.instructions.md
@@ -157,7 +157,7 @@ Agents that specify `Claude Opus 4.7` as priority model do so deliberately:
   apex-debug-log-export) use the same GPT-5.x prompting style as the Terra
   cohort (per vendor-prompting `family-support.md` — GPT-5.4 shares the OpenAI
   cohort rules). Lower-cost tier suits deterministic CLI workflows.
-- **MAI-Code-1-Flash agents** (orchestrator) run Microsoft's fast coding model
+- **MAI-Code-1.1-Flash agents** (orchestrator) run Microsoft's fast coding model
   for handoff-only routing with no creative generation. The `mai-code` family
   is `reviewer-only` in vendor-prompting — no MAI-specific automated rules yet;
   the orchestrator body keeps its outcome-first skeleton as a sound routing
@@ -185,7 +185,7 @@ Current model assignments:
 
 | Agent / Group                       | Model             | Rationale                                |
 | ----------------------------------- | ----------------- | ---------------------------------------- |
-| Orchestrator                        | MAI-Code-1-Flash  | Standard-tier handoff routing            |
+| Orchestrator                        | MAI-Code-1.1-Flash  | Standard-tier handoff routing            |
 | Orchestrator (Fast Path)            | GPT-5.6-Terra     | Streamlined orchestration                |
 | Requirements                        | Claude Sonnet 5   | One-shot discovery (Anthropic style)     |
 | Architect                           | Claude Opus 5     | WAF analysis + cost (high effort)        |

--- a/.github/model-catalog.json
+++ b/.github/model-catalog.json
@@ -162,7 +162,7 @@
       ],
       "notes": "Deprecated 2026-07 in favor of GPT-5.6-Luna. Retained for audit history; not authorized for active assignments."
     },
-    "MAI-Code-1-Flash": {
+    "MAI-Code-1.1-Flash": {
       "vendor": "Microsoft",
       "tier": "standard",
       "released": "2026-06",
@@ -188,7 +188,7 @@
     "generated_by": "tools/scripts/generate-model-catalog.mjs",
     "description": "Auto-generated inventory of agent → model assignments derived from frontmatter (canonical source). Do not edit by hand; run `node tools/scripts/generate-model-catalog.mjs` or let the lefthook pre-commit hook refresh it when frontmatter changes.",
     "agents": {
-      "01-orchestrator.agent.md": "MAI-Code-1-Flash",
+      "01-orchestrator.agent.md": "MAI-Code-1.1-Flash",
       "02-requirements.agent.md": "Claude Sonnet 5",
       "03-architect.agent.md": "Claude Opus 5",
       "04-design.agent.md": "Claude Sonnet 5",

--- a/.github/prompts/apex-debug-log-export.prompt.md
+++ b/.github/prompts/apex-debug-log-export.prompt.md
@@ -1,6 +1,6 @@
 ---
 agent: agent
-model: "MAI-Code-1-Flash"
+model: "MAI-Code-1.1-Flash"
 description: "Extract and compress Copilot debug logs related to custom agent activity into .apex-logs/ as a tar.gz bundle. User uploads the bundle manually to OneDrive via a provided link."
 argument-hint: "Optional OneDrive for Business share link to display in the final summary."
 tools: [vscode/askQuestions, execute/runInTerminal, read]

--- a/.github/prompts/apex-git-commit.prompt.md
+++ b/.github/prompts/apex-git-commit.prompt.md
@@ -1,6 +1,6 @@
 ---
 agent: agent
-model: "MAI-Code-1-Flash"
+model: "MAI-Code-1.1-Flash"
 description: "Stage everything except agent-output/, infra/, and .github/skills/sensei/ (unless on feat/skills-sensei), auto-generate a conventional commit, push, then prompt to open or update a PR. CLI-only (git + gh)."
 argument-hint: "Optional commit subject. Leave blank to auto-generate from the diff."
 tools: [vscode/askQuestions, execute/runInTerminal, read, todo]

--- a/.github/skills/docs-writer/references/repo-architecture.md
+++ b/.github/skills/docs-writer/references/repo-architecture.md
@@ -43,7 +43,7 @@ See `tools/registry/count-manifest.json` for canonical counts.
 
 | Agent             | File                             | Model                     | Step | Artifacts                       |
 | ----------------- | -------------------------------- | ------------------------- | ---- | ------------------------------- |
-| Orchestrator      | `01-orchestrator.agent.md`       | MAI-Code-1-Flash          | All  | Orchestration                   |
+| Orchestrator      | `01-orchestrator.agent.md`       | MAI-Code-1.1-Flash        | All  | Orchestration                   |
 | Requirements      | `02-requirements.agent.md`       | Claude Sonnet 5           | 1    | `01-requirements.md`            |
 | Architect         | `03-architect.agent.md`          | Claude Opus 5             | 2    | `02-architecture-assessment.md` |
 | Design            | `04-design.agent.md`             | Sonnet 5                  | 3    | `03-des-*.{drawio,py,png,md}`   |

--- a/.github/skills/vendor-prompting/references/family-support.md
+++ b/.github/skills/vendor-prompting/references/family-support.md
@@ -32,7 +32,7 @@ Family status determines per-rule severity overrides.
 | `gpt-5.4`       | enforced      | Shared OpenAI outcome-first rules                  | `GPT-5.4`           |
 | `gpt-codex`     | reviewer-only | Legacy decision-log compatibility                  | `GPT-5.3-Codex`     |
 | `gpt-4o`        | reviewer-only | Legacy; no new enforcement                         | `GPT-4o`            |
-| `mai-code`      | reviewer-only | Microsoft model; no MAI-specific prompting rules   | `MAI-Code-1-Flash`  |
+| `mai-code`      | reviewer-only | Microsoft model; no MAI-specific prompting rules   | `MAI-Code-1.1-Flash` |
 | `unknown`       | enforced      | Raises ERROR to force explicit `model:` value      | (anything else)     |
 
 ## How severity is computed

--- a/.github/skills/vendor-prompting/rules.json
+++ b/.github/skills/vendor-prompting/rules.json
@@ -97,7 +97,7 @@
     {
       "family": "mai-code",
       "status": "reviewer-only",
-      "label_examples": ["MAI-Code-1-Flash"],
+      "label_examples": ["MAI-Code-1.1-Flash"],
       "rule_subset_note": "Microsoft coding model; no MAI-specific automated prompting rules yet. Used for handoff-only orchestration routing."
     },
     {

--- a/site/public/architecture-explorer-graph.json
+++ b/site/public/architecture-explorer-graph.json
@@ -80,7 +80,7 @@
         "source": "https://github.com/jonathan-vella/apex/blob/main/.github/agents/01-orchestrator.agent.md"
       },
       "meta": {
-        "model": "MAI-Code-1-Flash",
+        "model": "MAI-Code-1.1-Flash",
         "invocable": true,
         "subagents": [
           "02-Requirements",

--- a/site/src/content/docs/concepts/how-it-works/agents.md
+++ b/site/src/content/docs/concepts/how-it-works/agents.md
@@ -267,7 +267,7 @@ Model selection depends on the task. Use `tools/registry/agent-registry.json` as
 source of truth, but the current repo pattern is:
 
 - **Planning agents** (accuracy-first) — `Claude Opus 5` at high reasoning effort
-- **Orchestrator** — `MAI-Code-1-Flash`, Microsoft's fast coding model. Standard
+- **Orchestrator** — `MAI-Code-1.1-Flash`, Microsoft's fast coding model. Standard
   tier suits handoff-only routing without creative generation; the agent body
   keeps its outcome-first skeleton (Role / Goal / Success / Constraints / Output /
   Stop) as a sound routing structure.

--- a/site/src/content/docs/concepts/workflow.md
+++ b/site/src/content/docs/concepts/workflow.md
@@ -136,7 +136,7 @@ preview subagents before any Azure changes are applied.
 
 | Agent            | Codename        | Role                                        | Model           |
 | ---------------- | --------------- | ------------------------------------------- | --------------- |
-| **Orchestrator** | 🧠 Orchestrator | Master orchestrator for multi-step workflow | MAI-Code-1-Flash |
+| **Orchestrator** | 🧠 Orchestrator | Master orchestrator for multi-step workflow | MAI-Code-1.1-Flash |
 
 ### Core Agents (by Workflow Step)
 

--- a/tools/registry/agent-registry.json
+++ b/tools/registry/agent-registry.json
@@ -4,7 +4,7 @@
   "agents": {
     "orchestrator": {
       "agent": ".github/agents/01-orchestrator.agent.md",
-      "model": "MAI-Code-1-Flash",
+      "model": "MAI-Code-1.1-Flash",
       "invokable": true,
       "step": null
     },

--- a/tools/tests/validate-agents/classify-model.test.mjs
+++ b/tools/tests/validate-agents/classify-model.test.mjs
@@ -56,9 +56,9 @@ test("classifyModel: GPT-4o → gpt-4o", () => {
   assert.equal(classifyModel("GPT-4o"), "gpt-4o");
 });
 
-test("classifyModel: MAI-Code-1-Flash → mai-code", () => {
-  assert.equal(classifyModel("MAI-Code-1-Flash"), "mai-code");
-  assert.equal(classifyModel(["MAI-Code-1-Flash"]), "mai-code");
+test("classifyModel: MAI-Code-1.1-Flash → mai-code", () => {
+  assert.equal(classifyModel("MAI-Code-1.1-Flash"), "mai-code");
+  assert.equal(classifyModel(["MAI-Code-1.1-Flash"]), "mai-code");
 });
 
 test("classifyModel: unknown / missing → unknown", () => {


### PR DESCRIPTION
## Summary
- replace active MAI-Code-1-Flash references with MAI-Code-1.1-Flash
- synchronize agent catalog, registry, prompts, authoring guidance, vendor metadata, tests, and site data
- retain existing mai-code family classification and handoff behavior

## Validation
- npm run test:classify-model
- npm run validate:model-catalog
- npm run validate:model-consistency
- npm run validate:deprecated-models
- npm run validate:agents
- npm run lint:vendor-prompting
- npm run lint:json
- npm run validate:explorer-graph
- npm run lint:md