### PR TITLE
fix(deps): resolve Dependabot alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 See the [published changelog](https://apexops.pro/project/changelog/)
 for full details on this and all prior releases.
 
+### Security
+
+- fix(deps): pin patched transitive releases for `undici`, `nanoid`, and
+  `brace-expansion`, resolving the open Dependabot advisories and producing
+  zero findings from both root and site npm audits.
+
 ### Added (Agent authoring skill)
 
 - feat(skills): add an on-demand `agent-authoring` workflow skill for creating,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1142,9 +1142,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4990,9 +4990,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -200,7 +200,8 @@
   "author": "Jonathan Vella",
   "license": "MIT",
   "overrides": {
-    "undici": ">=7.24.0",
+    "brace-expansion": "5.0.9",
+    "undici": "8.10.0",
     "dompurify": ">=3.3.2",
     "nanoid": ">=3.3.8",
     "mermaid": ">=11.4.1"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5460,9 +5460,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/site/package.json
+++ b/site/package.json
@@ -22,6 +22,7 @@
     "starlight-links-validator": "^0.25.3"
   },
   "overrides": {
-    "devalue": "^5.8.1"
+    "devalue": "^5.8.1",
+    "nanoid": "3.3.18"
   }
 }


### PR DESCRIPTION
## Security fixes
- override undici to 8.10.0, resolving alerts #167-#171 (patched in 8.9.0)
- override nanoid to 3.3.18, resolving alert #180
- override brace-expansion to 5.0.9, resolving the additional high-severity npm audit finding

## Verification
- npm audit --audit-level=low: 0 vulnerabilities
- npm --prefix site audit --audit-level=low: 0 vulnerabilities
- npm run validate:all: passed
- resolved trees: undici 8.10.0, nanoid 3.3.18, brace-expansion 5.0.9
- site build: 84 pages, 8,114 internal links