### PR TITLE
fix(scripts): address retirement scan review findings

### DIFF
--- a/.github/skills/azure-prepare/references/services/functions/templates/recipes/servicebus/source/dotnet.md
+++ b/.github/skills/azure-prepare/references/services/functions/templates/recipes/servicebus/source/dotnet.md
@@ -127,7 +127,7 @@ Set these in `local.settings.json`:
 ```
 
 > **Note:** For local development with UAMI, use Azure Identity `DefaultAzureCredential`
-> which will use your `az login` credentials. See [auth-best-practices.md](../../../../../../../entra-app-registration/references/auth-best-practices.md) for production guidance.
+> which will use your `az login` credentials. See [auth-best-practices.md](../../../../../../../../entra-app-registration/references/auth-best-practices.md) for production guidance.
 
 ## Common Patterns
 

--- a/.github/skills/azure-prepare/references/services/functions/templates/recipes/servicebus/source/java.md
+++ b/.github/skills/azure-prepare/references/services/functions/templates/recipes/servicebus/source/java.md
@@ -120,7 +120,7 @@ Set these in `local.settings.json`:
 ```
 
 > **Note:** For local development with UAMI, use Azure Identity `DefaultAzureCredential`
-> which will use your `az login` credentials. See [auth-best-practices.md](../../../../../../../entra-app-registration/references/auth-best-practices.md) for production guidance.
+> which will use your `az login` credentials. See [auth-best-practices.md](../../../../../../../../entra-app-registration/references/auth-best-practices.md) for production guidance.
 
 ## Common Patterns
 

--- a/.github/skills/azure-prepare/references/services/functions/templates/recipes/servicebus/source/powershell.md
+++ b/.github/skills/azure-prepare/references/services/functions/templates/recipes/servicebus/source/powershell.md
@@ -161,7 +161,7 @@ Set these in `local.settings.json`:
 ```
 
 > **Note:** For local development with UAMI, use Azure Identity `DefaultAzureCredential`
-> which will use your `az login` credentials. See [auth-best-practices.md](../../../../../../../entra-app-registration/references/auth-best-practices.md) for production guidance.
+> which will use your `az login` credentials. See [auth-best-practices.md](../../../../../../../../entra-app-registration/references/auth-best-practices.md) for production guidance.
 
 ## Common Patterns
 

--- a/.github/skills/azure-prepare/references/services/functions/templates/recipes/servicebus/source/python.md
+++ b/.github/skills/azure-prepare/references/services/functions/templates/recipes/servicebus/source/python.md
@@ -98,7 +98,7 @@ Set these in `local.settings.json`:
 ```
 
 > **Note:** For local development with UAMI, use Azure Identity `DefaultAzureCredential`
-> which will use your `az login` credentials. See [auth-best-practices.md](../../../../../../../entra-app-registration/references/auth-best-practices.md) for production guidance.
+> which will use your `az login` credentials. See [auth-best-practices.md](../../../../../../../../entra-app-registration/references/auth-best-practices.md) for production guidance.
 
 ## Common Patterns
 

--- a/site/src/content/docs/reference/validation-reference.md
+++ b/site/src/content/docs/reference/validation-reference.md
@@ -119,7 +119,7 @@ All scripts are in the `tools/scripts/` directory. Run via `npm run <command>`.
 | `lint:glob-audit`       | `validate-glob-audit.mjs`       | Detect overly broad glob patterns  |
 | `lint:orphaned-content` | `validate-orphaned-content.mjs` | Detect unreferenced skills/content |
 | `lint:docs-freshness`   | `check-docs-freshness.mjs`      | Documentation staleness detection  |
-| `validate:retirement-scan` | `audit-retirement-candidates.mjs` | Complete tracked-file census and schema validation |
+| `validate:retirement-scan` | `audit-retirement-candidates.mjs` | Tracked-file census and schema checks |
 | `lint:version-sync`     | `validate-version-sync.mjs`     | Version consistency across files   |
 
 ### Configuration Validators
@@ -149,7 +149,7 @@ All scripts are in the `tools/scripts/` directory. Run via `npm run <command>`.
 
 | npm Command          | Purpose                                       |
 | -------------------- | --------------------------------------------- |
-| `validate:all`       | Run all validators (cache-aware Node + external) |
+| `validate:all`       | Run cached Node and external validators          |
 | `validate:_node`     | Node validators in one cache-sharing process; bounded children for Python, ESLint, and tests |
 | `validate:_external` | All external tool validators in parallel      |
 | `validate:agents`    | Agent frontmatter, body, model alignment      |

--- a/tools/scripts/audit-retirement-candidates.mjs
+++ b/tools/scripts/audit-retirement-candidates.mjs
@@ -302,6 +302,7 @@ function jaccard(left, right) {
 
 function candidateReferences(textFiles, trackedPaths) {
   const references = new Map(trackedPaths.map((filePath) => [filePath, new Set()]));
+  const trackedPathSet = new Set(trackedPaths);
   const byBasename = new Map();
   for (const filePath of trackedPaths) {
     const basename = path.basename(filePath);
@@ -313,7 +314,7 @@ function candidateReferences(textFiles, trackedPaths) {
     for (const token of new Set(text.match(tokenPattern) ?? [])) {
       const clean = token.replace(/^[./]+/, "").replace(/[),:;]+$/, "");
       const relative = path.posix.normalize(path.posix.join(path.posix.dirname(sourcePath), clean));
-      const exact = trackedPaths.includes(clean) ? [clean] : trackedPaths.includes(relative) ? [relative] : [];
+      const exact = trackedPathSet.has(clean) ? [clean] : trackedPathSet.has(relative) ? [relative] : [];
       const basenameMatches = byBasename.get(path.basename(clean)) ?? [];
       const candidates = exact.length > 0 ? exact : basenameMatches.length === 1 ? basenameMatches : [];
       for (const target of candidates) {

--- a/tools/tests/audit-retirement-candidates.test.mjs
+++ b/tools/tests/audit-retirement-candidates.test.mjs
@@ -90,7 +90,7 @@ test("groups exact duplicates without approving retirement", () => {
 
 test("records repository ownership for every baseline file", () => {
   const result = scan();
-  assert.ok(result.inventory.every((item) => item.ownership.codeowners.includes("@jonathan-vella")));
+  assert.ok(result.inventory.every((item) => item.ownership.codeowners.length > 0));
 });
 
 test("resolves duplicated reference filenames relative to their owning skill", () => {

--- a/tools/tests/exec-plans/completed/whole-repo-retirement-scan-2026-08-27.md
+++ b/tools/tests/exec-plans/completed/whole-repo-retirement-scan-2026-08-27.md
@@ -254,7 +254,7 @@ framework. Any later archive execution must remain independently revertible by d
 - Every tracked file is represented exactly once in the validated inventory.
 - All candidate and defer findings complete adversarial review.
 - The report clearly separates protected, retained, candidate, and deferred content.
-- The branch stops at explicit human approval with no unapproved retirement actions.
+- Retirement actions require explicit human approval.
 
 ## Scan Result
 


### PR DESCRIPTION
## Description

Addresses all Copilot review findings raised after #672 merged.

## Related Issue

Follow-up to #672.

## Type of Change

- [x] Documentation update
- [x] Bug fix
- [x] Refactoring (no functional changes)

## Token / latency impact (Plan 01 Phase 5)

This change affects input-token budget / per-call latency:

- [x] NO

## Workflow Used

- [x] Direct implementation (simple change)

## Changes Made

- Correct deeply nested authentication-reference links.
- Shorten validation-reference table rows and clarify completed-plan approval wording.
- Remove a repository-specific CODEOWNER assertion.
- Use set membership for tracked-path reference lookups.

## Testing Performed

- [x] `node --test tools/tests/audit-retirement-candidates.test.mjs`
- [x] `npm run validate:retirement-scan`
- [x] `npm run lint:md`
- [x] Prettier, ESLint, link checks, and `git diff --check`

## Pre-Submission Checklist

- [x] PR touches fewer than 50 files
- [x] Commit message follows conventional commits
- [x] Review conversations on #672 are resolved
- [x] Markdown linting passes
- [x] Internal links verified
- [x] No hardcoded secrets or sensitive data

## Additional Notes

All Copilot threads on #672 report resolved.