### PR TITLE
docs: clarify validation cache scope

### DIFF
--- a/site/src/content/docs/reference/validation-reference.md
+++ b/site/src/content/docs/reference/validation-reference.md
@@ -149,7 +149,7 @@ All scripts are in the `tools/scripts/` directory. Run via `npm run <command>`.
 
 | npm Command          | Purpose                                       |
 | -------------------- | --------------------------------------------- |
-| `validate:all`       | Run cached Node and external validators          |
+| `validate:all`       | Run cache-aware Node validators plus external validators |
 | `validate:_node`     | Node validators in one cache-sharing process; bounded children for Python, ESLint, and tests |
 | `validate:_external` | All external tool validators in parallel      |
 | `validate:agents`    | Agent frontmatter, body, model alignment      |


### PR DESCRIPTION
## Description

Clarifies that caching applies to the Node validator suite, while external validators also run. Addresses the post-merge Copilot feedback on #673.

## Type of Change

- [x] Documentation update

## Token / latency impact (Plan 01 Phase 5)

- [x] NO

## Workflow Used

- [x] Direct implementation (simple change)

## Testing Performed

- [x] `npm run lint:md`
- [x] Markdown link check
- [x] `git diff --check`
- [x] Confirmed the edited row is 83 characters

## Pre-Submission Checklist

- [x] PR touches fewer than 50 files
- [x] Commit message follows conventional commits
- [x] Review conversation on #673 is resolved
- [x] Markdown linting passes
- [x] Internal links verified